### PR TITLE
Install pre-commit hooks in requirements.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,6 @@
+black==22.12.0
 kaggle==1.5.12
 pre-commit==2.21.0
+pre-commit-hooks==4.4.0
+pycln==2.1.2
 pytest==7.2.0

--- a/run.sh
+++ b/run.sh
@@ -10,8 +10,6 @@ install_python_requirements () {
     # Install Python dependencies
     pip3 install -r requirements-dev.txt
     pip3 install -r requirements.txt
-    # Install pre-commit hooks
-    pre-commit install --install-hooks
 }
 
 download_kaggle_data () {


### PR DESCRIPTION
Installing the hooks through `pre-commit` slows down the GitPod workspace startup. Since all of our hooks are Python packages, we can install them through `requirements-dev.txt` instead.

Some hooks are not shown in `requirements-dev.txt` because they are already required as dependencies of the other hooks.