### PR TITLE
Move Kaggle download and pre-commit to background tasks.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,6 +14,11 @@ github:
 # TODO(vinesh): Configure port for Jupyter notebook server
 ports: []
 tasks:
+  - name: Install Background
+    init: ./run.sh install-background
+    command: |
+      source .bash_aliases
+      source .venv/bin/activate
   - name: Install Project
     init: ./run.sh install-project
     command: |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,3 @@
-black==22.12.0
 kaggle==1.5.12
 pre-commit==2.21.0
-pre-commit-hooks==4.4.0
-pycln==2.1.2
 pytest==7.2.0

--- a/run.sh
+++ b/run.sh
@@ -12,6 +12,13 @@ install_python_requirements () {
     pip3 install -r requirements.txt
 }
 
+install_pre_commit () {
+    # Activate Python virtual environment
+    source .venv/bin/activate
+    # Install pre-commit hooks
+    pre-commit install --install-hooks
+}
+
 download_kaggle_data () {
     # Create necessary folders, if they do not exist
     mkdir -p data/zipped
@@ -27,12 +34,20 @@ download_kaggle_data () {
 }
 
 # Run commands based on chosen shortcut and options
+
+# Used to install main project dependencies needed for immediate development
 if [ "$1" == "install-project" ]; then
     # Install Python requirements
     install_python_requirements
+
+# Used to install dependencies in the background that will be used later
+elif [ "$1" == "install-background" ]; then
     # Download Kaggle data
     download_kaggle_data
+    # Install pre-commit
+    install_pre_commit
 
+# Used to install only Python requirements
 elif [ "$1" == "install-python-requirements" ]; then
     # Install Python requirements
     install_python_requirements


### PR DESCRIPTION
The previous PR #2 did not fully work because running `pre-commit` still installed the hooks. However, it did seem to speed up the GitHub actions.

Instead, we will split the installation process into a main installation and background installation, that way dependencies not needed immediately (Kaggle download and pre-commit installation) can happen in the background without affecting GitPod workspace startup time.