### PR TITLE
Return pocket metadata in addition to area.

### DIFF
--- a/notebooks/vinesh/example.ipynb
+++ b/notebooks/vinesh/example.ipynb
@@ -70,14 +70,14 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "12.566370614359172"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Object = PocketArea(area=12.566370614359172, metadata=PocketAreaMetadata(vertices=None, radius=2.0))\n",
+      "\n",
+      "Area   = 12.566\n",
+      "Radius = 2.0\n"
+     ]
     }
    ],
    "source": [
@@ -87,7 +87,10 @@
     "    {\"role\": \"rusher\", \"x\": 0, \"y\": 2},\n",
     "    {\"role\": \"rusher\", \"x\": 0, \"y\": 4},\n",
     "]\n",
-    "get_passer_radius_area(frame)"
+    "pocket_area = get_passer_radius_area(frame)\n",
+    "print(f\"Object = {pocket_area}\\n\")\n",
+    "print(f\"Area   = {pocket_area.area:.3f}\")\n",
+    "print(f\"Radius = {pocket_area.metadata.radius}\")"
    ]
   },
   {
@@ -107,7 +110,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pandas as pd"
+    "import pandas as pd\n",
+    "from src.pipeline.tasks import transform_to_frames, transform_to_records_per_frame"
    ]
   },
   {
@@ -216,11 +220,11 @@
    "source": [
     "df_pff_frame = df_pff.query(f\"gameId == {game_id} and playId == {play_id}\")\n",
     "df_tracking_frame = df_tracking.query(f\"gameId == {game_id} and playId == {play_id} and frameId == {frame_id}\")\n",
-    "df_frame_joined = df_tracking_frame.merge(df_pff, on=[\"gameId\", \"playId\", \"nflId\"], how=\"left\")\n",
-    "df_frame_joined[\"pff_role\"] = df_frame_joined[\"pff_role\"].fillna(\"Football\")\n",
-    "df_frame_joined[\"role\"] = df_frame_joined[\"pff_role\"].apply(convert_pff_role_to_pocket_role)\n",
-    "df_frame = df_frame_joined[[\"x\", \"y\", \"role\"]]\n",
-    "frame_dicts = df_frame.to_dict(orient=\"records\")\n",
+    "\n",
+    "df_frame = transform_to_frames(df_tracking_frame, df_pff_frame)\n",
+    "df_frame_records = transform_to_records_per_frame(df_frame)\n",
+    "\n",
+    "frame_dicts = df_frame_records[\"records\"][0]\n",
     "frame_dicts"
    ]
   },
@@ -231,18 +235,21 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "10.010684990663922"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Object = PocketArea(area=10.010684990663922, metadata=PocketAreaMetadata(vertices=None, radius=1.785077029150287))\n",
+      "\n",
+      "Area   = 10.011\n",
+      "Radius = 1.785077029150287\n"
+     ]
     }
    ],
    "source": [
-    "get_passer_radius_area(frame_dicts)"
+    "pocket_area = get_passer_radius_area(frame_dicts)\n",
+    "print(f\"Object = {pocket_area}\\n\")\n",
+    "print(f\"Area   = {pocket_area.area:.3f}\")\n",
+    "print(f\"Radius = {pocket_area.metadata.radius}\")"
    ]
   },
   {

--- a/notebooks/vinesh/pipeline_example.ipynb
+++ b/notebooks/vinesh/pipeline_example.ipynb
@@ -51,11 +51,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">08:20:26.438 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | prefect.engine - Created flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'sensible-jaybird'</span> for flow<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\"> 'main-flow'</span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:45:28.780 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | prefect.engine - Created flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'quiet-starling'</span> for flow<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\"> 'main-flow'</span>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "08:20:26.438 | \u001b[36mINFO\u001b[0m    | prefect.engine - Created flow run\u001b[35m 'sensible-jaybird'\u001b[0m for flow\u001b[1;35m 'main-flow'\u001b[0m\n"
+       "18:45:28.780 | \u001b[36mINFO\u001b[0m    | prefect.engine - Created flow run\u001b[35m 'quiet-starling'\u001b[0m for flow\u001b[1;35m 'main-flow'\u001b[0m\n"
       ]
      },
      "metadata": {},
@@ -64,11 +64,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">08:20:26.979 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'sensible-jaybird'</span> - Created task run 'read_csv-3609c996-0' for task 'read_csv'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:45:29.083 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'quiet-starling'</span> - Created task run 'read_csv-3609c996-0' for task 'read_csv'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "08:20:26.979 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'sensible-jaybird'\u001b[0m - Created task run 'read_csv-3609c996-0' for task 'read_csv'\n"
+       "18:45:29.083 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'quiet-starling'\u001b[0m - Created task run 'read_csv-3609c996-0' for task 'read_csv'\n"
       ]
      },
      "metadata": {},
@@ -77,11 +77,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">08:20:26.982 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'sensible-jaybird'</span> - Executing 'read_csv-3609c996-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:45:29.094 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'quiet-starling'</span> - Executing 'read_csv-3609c996-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "08:20:26.982 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'sensible-jaybird'\u001b[0m - Executing 'read_csv-3609c996-0' immediately...\n"
+       "18:45:29.094 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'quiet-starling'\u001b[0m - Executing 'read_csv-3609c996-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -90,11 +90,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">08:20:27.511 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'read_csv-3609c996-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:45:29.510 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'read_csv-3609c996-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "08:20:27.511 | \u001b[36mINFO\u001b[0m    | Task run 'read_csv-3609c996-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "18:45:29.510 | \u001b[36mINFO\u001b[0m    | Task run 'read_csv-3609c996-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -103,11 +103,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">08:20:27.646 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'sensible-jaybird'</span> - Created task run 'read_csv-3609c996-1' for task 'read_csv'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:45:29.558 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'quiet-starling'</span> - Created task run 'read_csv-3609c996-1' for task 'read_csv'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "08:20:27.646 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'sensible-jaybird'\u001b[0m - Created task run 'read_csv-3609c996-1' for task 'read_csv'\n"
+       "18:45:29.558 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'quiet-starling'\u001b[0m - Created task run 'read_csv-3609c996-1' for task 'read_csv'\n"
       ]
      },
      "metadata": {},
@@ -116,11 +116,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">08:20:27.648 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'sensible-jaybird'</span> - Executing 'read_csv-3609c996-1' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:45:29.562 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'quiet-starling'</span> - Executing 'read_csv-3609c996-1' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "08:20:27.648 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'sensible-jaybird'\u001b[0m - Executing 'read_csv-3609c996-1' immediately...\n"
+       "18:45:29.562 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'quiet-starling'\u001b[0m - Executing 'read_csv-3609c996-1' immediately...\n"
       ]
      },
      "metadata": {},
@@ -129,11 +129,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">08:20:29.917 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'read_csv-3609c996-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:45:31.781 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'read_csv-3609c996-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "08:20:29.917 | \u001b[36mINFO\u001b[0m    | Task run 'read_csv-3609c996-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "18:45:31.781 | \u001b[36mINFO\u001b[0m    | Task run 'read_csv-3609c996-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -142,11 +142,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">08:20:30.762 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'sensible-jaybird'</span> - Created task run 'transform_to_frames-3446c324-0' for task 'transform_to_frames'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:45:32.383 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'quiet-starling'</span> - Created task run 'transform_to_frames-3446c324-0' for task 'transform_to_frames'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "08:20:30.762 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'sensible-jaybird'\u001b[0m - Created task run 'transform_to_frames-3446c324-0' for task 'transform_to_frames'\n"
+       "18:45:32.383 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'quiet-starling'\u001b[0m - Created task run 'transform_to_frames-3446c324-0' for task 'transform_to_frames'\n"
       ]
      },
      "metadata": {},
@@ -155,11 +155,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">08:20:30.764 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'sensible-jaybird'</span> - Executing 'transform_to_frames-3446c324-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:45:32.385 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'quiet-starling'</span> - Executing 'transform_to_frames-3446c324-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "08:20:30.764 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'sensible-jaybird'\u001b[0m - Executing 'transform_to_frames-3446c324-0' immediately...\n"
+       "18:45:32.385 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'quiet-starling'\u001b[0m - Executing 'transform_to_frames-3446c324-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -168,11 +168,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">08:20:31.061 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'transform_to_frames-3446c324-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:45:32.517 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'transform_to_frames-3446c324-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "08:20:31.061 | \u001b[36mINFO\u001b[0m    | Task run 'transform_to_frames-3446c324-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "18:45:32.517 | \u001b[36mINFO\u001b[0m    | Task run 'transform_to_frames-3446c324-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -181,11 +181,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">08:20:31.142 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'sensible-jaybird'</span> - Created task run 'transform_to_records_per_frame-823b8998-0' for task 'transform_to_records_per_frame'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:45:32.550 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'quiet-starling'</span> - Created task run 'transform_to_records_per_frame-823b8998-0' for task 'transform_to_records_per_frame'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "08:20:31.142 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'sensible-jaybird'\u001b[0m - Created task run 'transform_to_records_per_frame-823b8998-0' for task 'transform_to_records_per_frame'\n"
+       "18:45:32.550 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'quiet-starling'\u001b[0m - Created task run 'transform_to_records_per_frame-823b8998-0' for task 'transform_to_records_per_frame'\n"
       ]
      },
      "metadata": {},
@@ -194,11 +194,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">08:20:31.146 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'sensible-jaybird'</span> - Executing 'transform_to_records_per_frame-823b8998-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:45:32.553 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'quiet-starling'</span> - Executing 'transform_to_records_per_frame-823b8998-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "08:20:31.146 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'sensible-jaybird'\u001b[0m - Executing 'transform_to_records_per_frame-823b8998-0' immediately...\n"
+       "18:45:32.553 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'quiet-starling'\u001b[0m - Executing 'transform_to_records_per_frame-823b8998-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -207,11 +207,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">08:20:31.472 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'transform_to_records_per_frame-823b8998-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:45:32.764 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'transform_to_records_per_frame-823b8998-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "08:20:31.472 | \u001b[36mINFO\u001b[0m    | Task run 'transform_to_records_per_frame-823b8998-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "18:45:32.764 | \u001b[36mINFO\u001b[0m    | Task run 'transform_to_records_per_frame-823b8998-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -220,11 +220,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">08:20:31.557 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'sensible-jaybird'</span> - Created task run 'calculate_pocket_area-cc18ef62-1' for task 'calculate_pocket_area'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:45:32.813 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'quiet-starling'</span> - Created task run 'calculate_pocket_area-cc18ef62-0' for task 'calculate_pocket_area'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "08:20:31.557 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'sensible-jaybird'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-1' for task 'calculate_pocket_area'\n"
+       "18:45:32.813 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'quiet-starling'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-0' for task 'calculate_pocket_area'\n"
       ]
      },
      "metadata": {},
@@ -233,11 +233,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">08:20:31.559 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'sensible-jaybird'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-1' for execution.\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:45:32.816 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'quiet-starling'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-0' for execution.\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "08:20:31.559 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'sensible-jaybird'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-1' for execution.\n"
+       "18:45:32.816 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'quiet-starling'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-0' for execution.\n"
       ]
      },
      "metadata": {},
@@ -246,11 +246,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">08:20:31.607 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'sensible-jaybird'</span> - Created task run 'calculate_pocket_area-cc18ef62-0' for task 'calculate_pocket_area'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:45:32.847 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'quiet-starling'</span> - Created task run 'calculate_pocket_area-cc18ef62-1' for task 'calculate_pocket_area'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "08:20:31.607 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'sensible-jaybird'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-0' for task 'calculate_pocket_area'\n"
+       "18:45:32.847 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'quiet-starling'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-1' for task 'calculate_pocket_area'\n"
       ]
      },
      "metadata": {},
@@ -259,11 +259,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">08:20:31.610 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'sensible-jaybird'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-0' for execution.\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:45:32.851 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'quiet-starling'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-1' for execution.\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "08:20:31.610 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'sensible-jaybird'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-0' for execution.\n"
+       "18:45:32.851 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'quiet-starling'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-1' for execution.\n"
       ]
      },
      "metadata": {},
@@ -272,11 +272,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">08:20:31.841 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'sensible-jaybird'</span> - Created task run 'union_dataframes-8a4e3d8f-0' for task 'union_dataframes'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:45:32.934 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'quiet-starling'</span> - Created task run 'union_dataframes-8a4e3d8f-0' for task 'union_dataframes'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "08:20:31.841 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'sensible-jaybird'\u001b[0m - Created task run 'union_dataframes-8a4e3d8f-0' for task 'union_dataframes'\n"
+       "18:45:32.934 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'quiet-starling'\u001b[0m - Created task run 'union_dataframes-8a4e3d8f-0' for task 'union_dataframes'\n"
       ]
      },
      "metadata": {},
@@ -285,11 +285,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">08:20:31.843 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'sensible-jaybird'</span> - Executing 'union_dataframes-8a4e3d8f-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:45:32.936 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'quiet-starling'</span> - Executing 'union_dataframes-8a4e3d8f-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "08:20:31.843 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'sensible-jaybird'\u001b[0m - Executing 'union_dataframes-8a4e3d8f-0' immediately...\n"
+       "18:45:32.936 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'quiet-starling'\u001b[0m - Executing 'union_dataframes-8a4e3d8f-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -298,11 +298,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">08:20:31.884 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:45:33.001 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "08:20:31.884 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "18:45:33.001 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -311,11 +311,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">08:20:31.958 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:45:33.040 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "08:20:31.958 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "18:45:33.040 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -324,11 +324,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">08:20:32.188 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'union_dataframes-8a4e3d8f-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:45:33.117 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'union_dataframes-8a4e3d8f-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "08:20:32.188 | \u001b[36mINFO\u001b[0m    | Task run 'union_dataframes-8a4e3d8f-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "18:45:33.117 | \u001b[36mINFO\u001b[0m    | Task run 'union_dataframes-8a4e3d8f-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -337,11 +337,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">08:20:32.294 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'sensible-jaybird'</span> - Created task run 'write_csv-386fe2af-0' for task 'write_csv'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:45:33.162 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'quiet-starling'</span> - Created task run 'write_csv-386fe2af-0' for task 'write_csv'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "08:20:32.294 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'sensible-jaybird'\u001b[0m - Created task run 'write_csv-386fe2af-0' for task 'write_csv'\n"
+       "18:45:33.162 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'quiet-starling'\u001b[0m - Created task run 'write_csv-386fe2af-0' for task 'write_csv'\n"
       ]
      },
      "metadata": {},
@@ -350,11 +350,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">08:20:32.297 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'sensible-jaybird'</span> - Executing 'write_csv-386fe2af-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:45:33.165 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'quiet-starling'</span> - Executing 'write_csv-386fe2af-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "08:20:32.297 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'sensible-jaybird'\u001b[0m - Executing 'write_csv-386fe2af-0' immediately...\n"
+       "18:45:33.165 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'quiet-starling'\u001b[0m - Executing 'write_csv-386fe2af-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -363,11 +363,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">08:20:32.524 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:45:33.262 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "08:20:32.524 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "18:45:33.262 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -376,11 +376,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">08:20:32.657 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'sensible-jaybird'</span> - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>('All states completed.')\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">18:45:33.316 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'quiet-starling'</span> - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>('All states completed.')\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "08:20:32.657 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'sensible-jaybird'\u001b[0m - Finished in state \u001b[32mCompleted\u001b[0m('All states completed.')\n"
+       "18:45:33.316 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'quiet-starling'\u001b[0m - Finished in state \u001b[32mCompleted\u001b[0m('All states completed.')\n"
       ]
      },
      "metadata": {},
@@ -432,6 +432,7 @@
        "      <th>playId</th>\n",
        "      <th>frameId</th>\n",
        "      <th>method</th>\n",
+       "      <th>pocket</th>\n",
        "      <th>area</th>\n",
        "    </tr>\n",
        "  </thead>\n",
@@ -442,6 +443,7 @@
        "      <td>97</td>\n",
        "      <td>1</td>\n",
        "      <td>passer_radius</td>\n",
+       "      <td>{'area': 104.72938933713064, 'metadata': {'ver...</td>\n",
        "      <td>104.729389</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -450,6 +452,7 @@
        "      <td>97</td>\n",
        "      <td>2</td>\n",
        "      <td>passer_radius</td>\n",
+       "      <td>{'area': 104.01436284917375, 'metadata': {'ver...</td>\n",
        "      <td>104.014363</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -458,6 +461,7 @@
        "      <td>97</td>\n",
        "      <td>3</td>\n",
        "      <td>passer_radius</td>\n",
+       "      <td>{'area': 103.95687170361305, 'metadata': {'ver...</td>\n",
        "      <td>103.956872</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -466,6 +470,7 @@
        "      <td>97</td>\n",
        "      <td>4</td>\n",
        "      <td>passer_radius</td>\n",
+       "      <td>{'area': 104.9172565778155, 'metadata': {'vert...</td>\n",
        "      <td>104.917257</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -474,6 +479,7 @@
        "      <td>97</td>\n",
        "      <td>5</td>\n",
        "      <td>passer_radius</td>\n",
+       "      <td>{'area': 105.33257512661999, 'metadata': {'ver...</td>\n",
        "      <td>105.332575</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -481,12 +487,19 @@
        "</div>"
       ],
       "text/plain": [
-       "       gameId  playId  frameId         method        area\n",
-       "0  2021090900      97        1  passer_radius  104.729389\n",
-       "1  2021090900      97        2  passer_radius  104.014363\n",
-       "2  2021090900      97        3  passer_radius  103.956872\n",
-       "3  2021090900      97        4  passer_radius  104.917257\n",
-       "4  2021090900      97        5  passer_radius  105.332575"
+       "       gameId  playId  frameId         method  \\\n",
+       "0  2021090900      97        1  passer_radius   \n",
+       "1  2021090900      97        2  passer_radius   \n",
+       "2  2021090900      97        3  passer_radius   \n",
+       "3  2021090900      97        4  passer_radius   \n",
+       "4  2021090900      97        5  passer_radius   \n",
+       "\n",
+       "                                              pocket        area  \n",
+       "0  {'area': 104.72938933713064, 'metadata': {'ver...  104.729389  \n",
+       "1  {'area': 104.01436284917375, 'metadata': {'ver...  104.014363  \n",
+       "2  {'area': 103.95687170361305, 'metadata': {'ver...  103.956872  \n",
+       "3  {'area': 104.9172565778155, 'metadata': {'vert...  104.917257  \n",
+       "4  {'area': 105.33257512661999, 'metadata': {'ver...  105.332575  "
       ]
      },
      "execution_count": 6,

--- a/src/metrics/pocket_area/all.py
+++ b/src/metrics/pocket_area/all.py
@@ -1,11 +1,11 @@
 from typing import Dict, List
 
-from src.metrics.pocket_area.base import PocketAreaFunction
+from src.metrics.pocket_area.base import PocketArea, PocketAreaFunction
 from src.metrics.pocket_area.passer_radius_area import get_passer_radius_area
 
 
-def always_zero(records: List[Dict]) -> float:
-    return 0
+def always_zero(records: List[Dict]) -> PocketArea:
+    return PocketArea(area=0)
 
 
 POCKET_AREA_METHODS: Dict[str, PocketAreaFunction] = {

--- a/src/metrics/pocket_area/base.py
+++ b/src/metrics/pocket_area/base.py
@@ -1,5 +1,18 @@
+from dataclasses import dataclass
 from enum import Enum
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Optional, Tuple
+
+
+@dataclass
+class PocketAreaMetadata:
+    vertices: Optional[List[Tuple[float, float]]] = None
+    radius: Optional[float] = None
+
+
+@dataclass
+class PocketArea:
+    area: float
+    metadata: PocketAreaMetadata = PocketAreaMetadata()
 
 
 class PocketRole(Enum):
@@ -26,7 +39,7 @@ PFF_ROLE_TO_POCKET_ROLE: Dict[PFFRole, PocketRole] = {
 }
 
 # Type hint for functions that compute pocket area
-PocketAreaFunction = Callable[[List[Dict]], float]
+PocketAreaFunction = Callable[[List[Dict]], PocketArea]
 
 
 class InvalidPocketError(Exception):

--- a/src/metrics/pocket_area/passer_radius_area.py
+++ b/src/metrics/pocket_area/passer_radius_area.py
@@ -1,7 +1,11 @@
 import math
 from typing import Dict, List, Tuple
 
-from src.metrics.pocket_area.base import InvalidPocketError
+from src.metrics.pocket_area.base import (
+    InvalidPocketError,
+    PocketArea,
+    PocketAreaMetadata,
+)
 from src.metrics.pocket_area.helpers import get_distance, split_records_by_role
 
 PlayerAndDistance = Tuple[Dict, float]
@@ -30,7 +34,7 @@ def get_circle_area(radius: float) -> float:
     return area
 
 
-def get_passer_radius_area(frame: List[Dict]) -> float:
+def get_passer_radius_area(frame: List[Dict]) -> PocketArea:
     """
     Estimates the pocket area as the area of a circle where the radius is the
     distance from the passer to the closest rusher.
@@ -40,4 +44,6 @@ def get_passer_radius_area(frame: List[Dict]) -> float:
         raise InvalidPocketError("No rushers in frame.")
 
     closest_rusher, distance = find_closest_player(passer, rushers)
-    return get_circle_area(radius=distance)
+    area = get_circle_area(radius=distance)
+    metadata = PocketAreaMetadata(radius=distance)
+    return PocketArea(area, metadata)

--- a/src/metrics/pocket_area/passer_radius_area_test.py
+++ b/src/metrics/pocket_area/passer_radius_area_test.py
@@ -13,7 +13,8 @@ def test_get_passer_radius_area():
     ]
     actual = get_passer_radius_area(frame)
     # Closest rusher is 2 units away, so area is: 3.14 * (2^2) ~= 12.5
-    assert actual == pytest.approx(12.566370)
+    assert actual.area == pytest.approx(12.566370)
+    assert actual.metadata.radius == 2
 
 
 def test_get_passer_radius_area_no_rushers():

--- a/src/pipeline/tasks/pocket_area_test.py
+++ b/src/pipeline/tasks/pocket_area_test.py
@@ -1,8 +1,15 @@
+import re
 from typing import Dict, List
 
+import numpy as np
 import pandas as pd
+import pytest
 
-from src.pipeline.tasks.pocket_area import calculate_pocket_area
+from src.metrics.pocket_area.base import PocketArea, PocketAreaMetadata
+from src.pipeline.tasks.pocket_area import (
+    calculate_pocket_area,
+    calculate_pocket_safely,
+)
 
 
 def test_calculate_pocket_area():
@@ -21,10 +28,10 @@ def test_calculate_pocket_area():
         ]
     )
 
-    def calculate_area(records: List[Dict]) -> float:
-        return 7
+    def calculate_area_always_seven(records: List[Dict]) -> PocketArea:
+        return PocketArea(area=7)
 
-    method = ("always_seven", calculate_area)
+    method = ("always_seven", calculate_area_always_seven)
     actual = calculate_pocket_area(df, method)
     expected = [
         {
@@ -32,7 +39,52 @@ def test_calculate_pocket_area():
             "playId": 1,
             "frameId": 1,
             "method": "always_seven",
+            "pocket": {
+                "area": 7,
+                "metadata": {
+                    "vertices": None,
+                    "radius": None,
+                },
+            },
             "area": 7,
         },
     ]
     assert actual.to_dict(orient="records") == expected
+
+
+def test_calculate_pocket_safely():
+    def calculate_area_always_seven(records: List[Dict]) -> PocketArea:
+        return PocketArea(area=7)
+
+    actual_fn = calculate_pocket_safely(calculate_area_always_seven)
+
+    df = pd.DataFrame()
+    actual = actual_fn(df)
+    expected = {"area": 7, "metadata": {"vertices": None, "radius": None}}
+    assert actual == expected
+
+
+def test_calculate_pocket_safely_with_exception():
+    def calculate_area_raises_exception(records: List[Dict]) -> PocketArea:
+        raise Exception("This function does not work.")
+
+    actual_fn = calculate_pocket_safely(calculate_area_raises_exception)
+
+    df = pd.DataFrame()
+    actual = actual_fn(df)
+    expected = {"area": np.nan, "metadata": {"vertices": None, "radius": None}}
+    assert actual == expected
+
+
+def test_calculate_pocket_safely_with_invalid_function():
+    def calculate_area_returns_wrong_type(records: List[Dict]) -> float:
+        return 6
+
+    actual_fn = calculate_pocket_safely(calculate_area_returns_wrong_type)
+
+    expected = re.escape(
+        "Function calculate_area_returns_wrong_type() returned int instead of PocketArea."
+    )
+    with pytest.raises(TypeError, match=expected):
+        df = pd.DataFrame()
+        actual_fn(df)


### PR DESCRIPTION
In order to make it easier to visualize the pocket area, each pocket area function should return a dataclass object `PocketArea` instead of just the `float` for the area.

`PocketArea` has nested dataclass called `PocketAreaMetadata` where we can store optional information about the shape of the pocket. For example, a circular pocket can populate the radius (and assume the center is the passer) and a convex hull pocket can populate the list of vertices.

When the pipeline runs, it takes this output and stores it as a column with a dictionary containing the information:

<img width="733" alt="Screen Shot 2022-12-28 at 12 52 45 PM" src="https://user-images.githubusercontent.com/11896652/209859445-7f661335-bb0e-4b35-840b-14a924711416.png">

Then, a separate visualization function can read the metadata and display the pocket. I will write the visualization code in a separate pull request, this pull request is the first step to enable it.