### PR TITLE
Move all GitPod startup tasks to command instead of init.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -18,24 +18,21 @@ ports:
     visibility: public
 tasks:
   - name: Background
-    init: |
-      gp sync-await install-project
-      ./run.sh install-background
     command: |
+      gp sync-await install-project
       source .bash_helpers
       source .venv/bin/activate
+      ./run.sh install-background
       pre-commit install --install-hooks
   - name: Jupyter
-    init: |
-      gp sync-await install-project
-      ./run.sh jupyter
     command: |
+      gp sync-await install-project
       source .bash_helpers
       source .venv/bin/activate
+      ./run.sh jupyter
   - name: Main
-    init: |
+    command: |
       ./run.sh install-project
       gp sync-done install-project
-    command: |
       source .bash_helpers
       source .venv/bin/activate


### PR DESCRIPTION
We were experiencing issues where a GitPod instance would go inactive and then upon reactivating, some startup commands did not run.

I think the root cause is that the `init` tasks do not run again when a workspace reactivates and some of those tasks are not localized to the `workspace` directory, so their changes do not persist on reactivation.

To (hopefully) solve this, I moved all startup tasks to `command`. This means we will not benefit from prebuilds, but we were not using that feature anyway as it is only available for individuals on the free tier, not teams.