### PR TITLE
Reorient tracking data to face the same way.

### DIFF
--- a/notebooks/vinesh/reorient_tracking_data.ipynb
+++ b/notebooks/vinesh/reorient_tracking_data.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "54c8dabc",
+   "id": "7ae6c527",
    "metadata": {},
    "source": [
     "# Reorient Tracking Data"
@@ -11,7 +11,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "321aa765",
+   "id": "a0d45bf1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -22,7 +22,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "9174df2b",
+   "id": "bd621f3a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,7 +34,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "8df9b674",
+   "id": "697049b9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -48,17 +48,17 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "d75a4dc0",
+   "id": "f00f809e",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:25.751 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | prefect.engine - Created flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> for flow<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\"> 'main-flow'</span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:20.126 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | prefect.engine - Created flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'pink-loon'</span> for flow<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\"> 'main-flow'</span>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:25.751 | \u001b[36mINFO\u001b[0m    | prefect.engine - Created flow run\u001b[35m 'amethyst-mole'\u001b[0m for flow\u001b[1;35m 'main-flow'\u001b[0m\n"
+       "23:10:20.126 | \u001b[36mINFO\u001b[0m    | prefect.engine - Created flow run\u001b[35m 'pink-loon'\u001b[0m for flow\u001b[1;35m 'main-flow'\u001b[0m\n"
       ]
      },
      "metadata": {},
@@ -67,11 +67,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:25.906 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Created task run 'read_csv-3609c996-0' for task 'read_csv'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:20.275 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'pink-loon'</span> - Created task run 'read_csv-3609c996-0' for task 'read_csv'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:25.906 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Created task run 'read_csv-3609c996-0' for task 'read_csv'\n"
+       "23:10:20.275 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'pink-loon'\u001b[0m - Created task run 'read_csv-3609c996-0' for task 'read_csv'\n"
       ]
      },
      "metadata": {},
@@ -80,11 +80,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:25.908 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Executing 'read_csv-3609c996-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:20.278 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'pink-loon'</span> - Executing 'read_csv-3609c996-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:25.908 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Executing 'read_csv-3609c996-0' immediately...\n"
+       "23:10:20.278 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'pink-loon'\u001b[0m - Executing 'read_csv-3609c996-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -93,11 +93,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:26.476 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'read_csv-3609c996-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:20.655 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'read_csv-3609c996-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:26.476 | \u001b[36mINFO\u001b[0m    | Task run 'read_csv-3609c996-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "23:10:20.655 | \u001b[36mINFO\u001b[0m    | Task run 'read_csv-3609c996-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -106,11 +106,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:26.501 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Created task run 'read_csv-3609c996-1' for task 'read_csv'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:20.679 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'pink-loon'</span> - Created task run 'read_csv-3609c996-1' for task 'read_csv'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:26.501 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Created task run 'read_csv-3609c996-1' for task 'read_csv'\n"
+       "23:10:20.679 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'pink-loon'\u001b[0m - Created task run 'read_csv-3609c996-1' for task 'read_csv'\n"
       ]
      },
      "metadata": {},
@@ -119,11 +119,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:26.503 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Executing 'read_csv-3609c996-1' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:20.681 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'pink-loon'</span> - Executing 'read_csv-3609c996-1' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:26.503 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Executing 'read_csv-3609c996-1' immediately...\n"
+       "23:10:20.681 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'pink-loon'\u001b[0m - Executing 'read_csv-3609c996-1' immediately...\n"
       ]
      },
      "metadata": {},
@@ -132,11 +132,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:26.593 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'read_csv-3609c996-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:20.762 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'read_csv-3609c996-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:26.593 | \u001b[36mINFO\u001b[0m    | Task run 'read_csv-3609c996-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "23:10:20.762 | \u001b[36mINFO\u001b[0m    | Task run 'read_csv-3609c996-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -145,11 +145,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:26.617 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Created task run 'read_csv-3609c996-2' for task 'read_csv'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:20.786 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'pink-loon'</span> - Created task run 'read_csv-3609c996-2' for task 'read_csv'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:26.617 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Created task run 'read_csv-3609c996-2' for task 'read_csv'\n"
+       "23:10:20.786 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'pink-loon'\u001b[0m - Created task run 'read_csv-3609c996-2' for task 'read_csv'\n"
       ]
      },
      "metadata": {},
@@ -158,11 +158,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:26.619 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Executing 'read_csv-3609c996-2' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:20.788 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'pink-loon'</span> - Executing 'read_csv-3609c996-2' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:26.619 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Executing 'read_csv-3609c996-2' immediately...\n"
+       "23:10:20.788 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'pink-loon'\u001b[0m - Executing 'read_csv-3609c996-2' immediately...\n"
       ]
      },
      "metadata": {},
@@ -171,11 +171,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:28.613 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'read_csv-3609c996-2' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:22.881 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'read_csv-3609c996-2' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:28.613 | \u001b[36mINFO\u001b[0m    | Task run 'read_csv-3609c996-2' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "23:10:22.881 | \u001b[36mINFO\u001b[0m    | Task run 'read_csv-3609c996-2' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -184,11 +184,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.013 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Created task run 'transform_to_tracking_display-0c78dc49-0' for task 'transform_to_tracking_display'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:27.250 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'pink-loon'</span> - Created task run 'transform_to_tracking_display-0c78dc49-0' for task 'transform_to_tracking_display'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:33.013 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Created task run 'transform_to_tracking_display-0c78dc49-0' for task 'transform_to_tracking_display'\n"
+       "23:10:27.250 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'pink-loon'\u001b[0m - Created task run 'transform_to_tracking_display-0c78dc49-0' for task 'transform_to_tracking_display'\n"
       ]
      },
      "metadata": {},
@@ -197,11 +197,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.015 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Executing 'transform_to_tracking_display-0c78dc49-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:27.252 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'pink-loon'</span> - Executing 'transform_to_tracking_display-0c78dc49-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:33.015 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Executing 'transform_to_tracking_display-0c78dc49-0' immediately...\n"
+       "23:10:27.252 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'pink-loon'\u001b[0m - Executing 'transform_to_tracking_display-0c78dc49-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -210,11 +210,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.117 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'transform_to_tracking_display-0c78dc49-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:27.364 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'transform_to_tracking_display-0c78dc49-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:33.117 | \u001b[36mINFO\u001b[0m    | Task run 'transform_to_tracking_display-0c78dc49-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "23:10:27.364 | \u001b[36mINFO\u001b[0m    | Task run 'transform_to_tracking_display-0c78dc49-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -223,11 +223,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.140 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Created task run 'transform_to_frames-3446c324-0' for task 'transform_to_frames'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:27.390 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'pink-loon'</span> - Created task run 'transform_to_frames-3446c324-0' for task 'transform_to_frames'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:33.140 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Created task run 'transform_to_frames-3446c324-0' for task 'transform_to_frames'\n"
+       "23:10:27.390 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'pink-loon'\u001b[0m - Created task run 'transform_to_frames-3446c324-0' for task 'transform_to_frames'\n"
       ]
      },
      "metadata": {},
@@ -236,11 +236,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.142 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Executing 'transform_to_frames-3446c324-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:27.392 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'pink-loon'</span> - Executing 'transform_to_frames-3446c324-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:33.142 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Executing 'transform_to_frames-3446c324-0' immediately...\n"
+       "23:10:27.392 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'pink-loon'\u001b[0m - Executing 'transform_to_frames-3446c324-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -249,11 +249,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.256 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'transform_to_frames-3446c324-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:27.516 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'transform_to_frames-3446c324-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:33.256 | \u001b[36mINFO\u001b[0m    | Task run 'transform_to_frames-3446c324-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "23:10:27.516 | \u001b[36mINFO\u001b[0m    | Task run 'transform_to_frames-3446c324-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -262,11 +262,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.279 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Created task run 'transform_to_records_per_frame-823b8998-0' for task 'transform_to_records_per_frame'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:27.542 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'pink-loon'</span> - Created task run 'transform_to_records_per_frame-823b8998-0' for task 'transform_to_records_per_frame'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:33.279 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Created task run 'transform_to_records_per_frame-823b8998-0' for task 'transform_to_records_per_frame'\n"
+       "23:10:27.542 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'pink-loon'\u001b[0m - Created task run 'transform_to_records_per_frame-823b8998-0' for task 'transform_to_records_per_frame'\n"
       ]
      },
      "metadata": {},
@@ -275,11 +275,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.281 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Executing 'transform_to_records_per_frame-823b8998-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:27.544 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'pink-loon'</span> - Executing 'transform_to_records_per_frame-823b8998-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:33.281 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Executing 'transform_to_records_per_frame-823b8998-0' immediately...\n"
+       "23:10:27.544 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'pink-loon'\u001b[0m - Executing 'transform_to_records_per_frame-823b8998-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -288,11 +288,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.634 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'transform_to_records_per_frame-823b8998-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:27.898 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'transform_to_records_per_frame-823b8998-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:33.634 | \u001b[36mINFO\u001b[0m    | Task run 'transform_to_records_per_frame-823b8998-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "23:10:27.898 | \u001b[36mINFO\u001b[0m    | Task run 'transform_to_records_per_frame-823b8998-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -301,11 +301,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.667 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Created task run 'calculate_pocket_area-cc18ef62-1' for task 'calculate_pocket_area'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:27.932 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'pink-loon'</span> - Created task run 'calculate_pocket_area-cc18ef62-0' for task 'calculate_pocket_area'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:33.667 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-1' for task 'calculate_pocket_area'\n"
+       "23:10:27.932 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'pink-loon'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-0' for task 'calculate_pocket_area'\n"
       ]
      },
      "metadata": {},
@@ -314,11 +314,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.669 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-1' for execution.\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:27.934 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'pink-loon'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-0' for execution.\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:33.669 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-1' for execution.\n"
+       "23:10:27.934 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'pink-loon'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-0' for execution.\n"
       ]
      },
      "metadata": {},
@@ -327,11 +327,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.693 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Created task run 'calculate_pocket_area-cc18ef62-0' for task 'calculate_pocket_area'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:27.957 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'pink-loon'</span> - Created task run 'calculate_pocket_area-cc18ef62-1' for task 'calculate_pocket_area'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:33.693 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-0' for task 'calculate_pocket_area'\n"
+       "23:10:27.957 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'pink-loon'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-1' for task 'calculate_pocket_area'\n"
       ]
      },
      "metadata": {},
@@ -340,11 +340,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.695 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-0' for execution.\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:27.959 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'pink-loon'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-1' for execution.\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:33.695 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-0' for execution.\n"
+       "23:10:27.959 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'pink-loon'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-1' for execution.\n"
       ]
      },
      "metadata": {},
@@ -353,11 +353,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.757 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Created task run 'union_dataframes-8a4e3d8f-0' for task 'union_dataframes'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:28.066 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'pink-loon'</span> - Created task run 'union_dataframes-8a4e3d8f-0' for task 'union_dataframes'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:33.757 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Created task run 'union_dataframes-8a4e3d8f-0' for task 'union_dataframes'\n"
+       "23:10:28.066 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'pink-loon'\u001b[0m - Created task run 'union_dataframes-8a4e3d8f-0' for task 'union_dataframes'\n"
       ]
      },
      "metadata": {},
@@ -366,11 +366,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.760 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Executing 'union_dataframes-8a4e3d8f-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:28.068 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'pink-loon'</span> - Executing 'union_dataframes-8a4e3d8f-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:33.760 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Executing 'union_dataframes-8a4e3d8f-0' immediately...\n"
+       "23:10:28.068 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'pink-loon'\u001b[0m - Executing 'union_dataframes-8a4e3d8f-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -379,11 +379,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.888 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:28.098 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:33.888 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "23:10:28.098 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -392,11 +392,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.974 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:28.207 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:33.974 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "23:10:28.207 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -405,11 +405,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.027 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'union_dataframes-8a4e3d8f-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:28.262 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'union_dataframes-8a4e3d8f-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:34.027 | \u001b[36mINFO\u001b[0m    | Task run 'union_dataframes-8a4e3d8f-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "23:10:28.262 | \u001b[36mINFO\u001b[0m    | Task run 'union_dataframes-8a4e3d8f-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -418,11 +418,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.050 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Created task run 'write_csv-386fe2af-0' for task 'write_csv'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:28.285 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'pink-loon'</span> - Created task run 'write_csv-386fe2af-0' for task 'write_csv'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:34.050 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Created task run 'write_csv-386fe2af-0' for task 'write_csv'\n"
+       "23:10:28.285 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'pink-loon'\u001b[0m - Created task run 'write_csv-386fe2af-0' for task 'write_csv'\n"
       ]
      },
      "metadata": {},
@@ -431,11 +431,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.052 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Executing 'write_csv-386fe2af-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:28.287 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'pink-loon'</span> - Executing 'write_csv-386fe2af-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:34.052 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Executing 'write_csv-386fe2af-0' immediately...\n"
+       "23:10:28.287 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'pink-loon'\u001b[0m - Executing 'write_csv-386fe2af-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -444,11 +444,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.155 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:28.392 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:34.155 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "23:10:28.392 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -457,11 +457,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.179 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Created task run 'write_csv-386fe2af-1' for task 'write_csv'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:28.415 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'pink-loon'</span> - Created task run 'write_csv-386fe2af-1' for task 'write_csv'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:34.179 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Created task run 'write_csv-386fe2af-1' for task 'write_csv'\n"
+       "23:10:28.415 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'pink-loon'\u001b[0m - Created task run 'write_csv-386fe2af-1' for task 'write_csv'\n"
       ]
      },
      "metadata": {},
@@ -470,11 +470,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.181 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Executing 'write_csv-386fe2af-1' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:28.417 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'pink-loon'</span> - Executing 'write_csv-386fe2af-1' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:34.181 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Executing 'write_csv-386fe2af-1' immediately...\n"
+       "23:10:28.417 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'pink-loon'\u001b[0m - Executing 'write_csv-386fe2af-1' immediately...\n"
       ]
      },
      "metadata": {},
@@ -483,11 +483,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.234 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:28.470 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:34.234 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "23:10:28.470 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -496,11 +496,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.256 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Created task run 'write_csv-386fe2af-2' for task 'write_csv'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:28.498 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'pink-loon'</span> - Created task run 'write_csv-386fe2af-2' for task 'write_csv'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:34.256 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Created task run 'write_csv-386fe2af-2' for task 'write_csv'\n"
+       "23:10:28.498 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'pink-loon'\u001b[0m - Created task run 'write_csv-386fe2af-2' for task 'write_csv'\n"
       ]
      },
      "metadata": {},
@@ -509,11 +509,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.258 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Executing 'write_csv-386fe2af-2' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:28.500 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'pink-loon'</span> - Executing 'write_csv-386fe2af-2' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:34.258 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Executing 'write_csv-386fe2af-2' immediately...\n"
+       "23:10:28.500 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'pink-loon'\u001b[0m - Executing 'write_csv-386fe2af-2' immediately...\n"
       ]
      },
      "metadata": {},
@@ -522,11 +522,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.340 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-2' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:28.599 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-2' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:34.340 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-2' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "23:10:28.599 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-2' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -535,11 +535,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.367 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Created task run 'write_csv-386fe2af-3' for task 'write_csv'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:28.627 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'pink-loon'</span> - Created task run 'write_csv-386fe2af-3' for task 'write_csv'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:34.367 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Created task run 'write_csv-386fe2af-3' for task 'write_csv'\n"
+       "23:10:28.627 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'pink-loon'\u001b[0m - Created task run 'write_csv-386fe2af-3' for task 'write_csv'\n"
       ]
      },
      "metadata": {},
@@ -548,11 +548,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.369 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Executing 'write_csv-386fe2af-3' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:28.629 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'pink-loon'</span> - Executing 'write_csv-386fe2af-3' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:34.369 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Executing 'write_csv-386fe2af-3' immediately...\n"
+       "23:10:28.629 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'pink-loon'\u001b[0m - Executing 'write_csv-386fe2af-3' immediately...\n"
       ]
      },
      "metadata": {},
@@ -561,11 +561,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.443 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-3' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:28.727 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-3' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:34.443 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-3' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "23:10:28.727 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-3' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -574,11 +574,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.467 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Created task run 'write_csv-386fe2af-4' for task 'write_csv'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:28.755 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'pink-loon'</span> - Created task run 'write_csv-386fe2af-4' for task 'write_csv'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:34.467 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Created task run 'write_csv-386fe2af-4' for task 'write_csv'\n"
+       "23:10:28.755 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'pink-loon'\u001b[0m - Created task run 'write_csv-386fe2af-4' for task 'write_csv'\n"
       ]
      },
      "metadata": {},
@@ -587,11 +587,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.469 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Executing 'write_csv-386fe2af-4' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:28.757 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'pink-loon'</span> - Executing 'write_csv-386fe2af-4' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:34.469 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Executing 'write_csv-386fe2af-4' immediately...\n"
+       "23:10:28.757 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'pink-loon'\u001b[0m - Executing 'write_csv-386fe2af-4' immediately...\n"
       ]
      },
      "metadata": {},
@@ -600,11 +600,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.532 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-4' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:28.818 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-4' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:34.532 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-4' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "23:10:28.818 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-4' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -613,11 +613,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.567 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>('All states completed.')\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">23:10:28.857 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'pink-loon'</span> - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>('All states completed.')\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "22:50:34.567 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Finished in state \u001b[32mCompleted\u001b[0m('All states completed.')\n"
+       "23:10:28.857 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'pink-loon'\u001b[0m - Finished in state \u001b[32mCompleted\u001b[0m('All states completed.')\n"
       ]
      },
      "metadata": {},
@@ -631,7 +631,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "d327a87d",
+   "id": "d7914807",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -643,14 +643,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "21daeaa7",
+   "execution_count": 6,
+   "id": "12f1f71e",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3cc19b3e449b4e93871bd449607f7ffd",
+       "model_id": "fba66053bbaa41d8a666d0f3cc78ea34",
        "version_major": 2,
        "version_minor": 0
       },
@@ -674,7 +674,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bafe0987",
+   "id": "be1895b4",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/notebooks/vinesh/reorient_tracking_data.ipynb
+++ b/notebooks/vinesh/reorient_tracking_data.ipynb
@@ -1,0 +1,704 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "54c8dabc",
+   "metadata": {},
+   "source": [
+    "# Reorient Tracking Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "321aa765",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "9174df2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "DIR = \"/workspace/nflbigdatabowl2023\"\n",
+    "sys.path.append(DIR)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "8df9b674",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ast import literal_eval\n",
+    "import pandas as pd\n",
+    "\n",
+    "from src.pipeline.flows.main import main_flow\n",
+    "from src.visualization.interactive_play_selector import create_interactive_play_selector"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "d75a4dc0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:25.751 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | prefect.engine - Created flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> for flow<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\"> 'main-flow'</span>\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:25.751 | \u001b[36mINFO\u001b[0m    | prefect.engine - Created flow run\u001b[35m 'amethyst-mole'\u001b[0m for flow\u001b[1;35m 'main-flow'\u001b[0m\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:25.906 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Created task run 'read_csv-3609c996-0' for task 'read_csv'\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:25.906 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Created task run 'read_csv-3609c996-0' for task 'read_csv'\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:25.908 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Executing 'read_csv-3609c996-0' immediately...\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:25.908 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Executing 'read_csv-3609c996-0' immediately...\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:26.476 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'read_csv-3609c996-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:26.476 | \u001b[36mINFO\u001b[0m    | Task run 'read_csv-3609c996-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:26.501 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Created task run 'read_csv-3609c996-1' for task 'read_csv'\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:26.501 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Created task run 'read_csv-3609c996-1' for task 'read_csv'\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:26.503 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Executing 'read_csv-3609c996-1' immediately...\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:26.503 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Executing 'read_csv-3609c996-1' immediately...\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:26.593 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'read_csv-3609c996-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:26.593 | \u001b[36mINFO\u001b[0m    | Task run 'read_csv-3609c996-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:26.617 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Created task run 'read_csv-3609c996-2' for task 'read_csv'\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:26.617 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Created task run 'read_csv-3609c996-2' for task 'read_csv'\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:26.619 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Executing 'read_csv-3609c996-2' immediately...\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:26.619 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Executing 'read_csv-3609c996-2' immediately...\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:28.613 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'read_csv-3609c996-2' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:28.613 | \u001b[36mINFO\u001b[0m    | Task run 'read_csv-3609c996-2' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.013 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Created task run 'transform_to_tracking_display-0c78dc49-0' for task 'transform_to_tracking_display'\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:33.013 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Created task run 'transform_to_tracking_display-0c78dc49-0' for task 'transform_to_tracking_display'\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.015 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Executing 'transform_to_tracking_display-0c78dc49-0' immediately...\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:33.015 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Executing 'transform_to_tracking_display-0c78dc49-0' immediately...\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.117 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'transform_to_tracking_display-0c78dc49-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:33.117 | \u001b[36mINFO\u001b[0m    | Task run 'transform_to_tracking_display-0c78dc49-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.140 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Created task run 'transform_to_frames-3446c324-0' for task 'transform_to_frames'\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:33.140 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Created task run 'transform_to_frames-3446c324-0' for task 'transform_to_frames'\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.142 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Executing 'transform_to_frames-3446c324-0' immediately...\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:33.142 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Executing 'transform_to_frames-3446c324-0' immediately...\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.256 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'transform_to_frames-3446c324-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:33.256 | \u001b[36mINFO\u001b[0m    | Task run 'transform_to_frames-3446c324-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.279 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Created task run 'transform_to_records_per_frame-823b8998-0' for task 'transform_to_records_per_frame'\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:33.279 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Created task run 'transform_to_records_per_frame-823b8998-0' for task 'transform_to_records_per_frame'\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.281 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Executing 'transform_to_records_per_frame-823b8998-0' immediately...\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:33.281 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Executing 'transform_to_records_per_frame-823b8998-0' immediately...\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.634 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'transform_to_records_per_frame-823b8998-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:33.634 | \u001b[36mINFO\u001b[0m    | Task run 'transform_to_records_per_frame-823b8998-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.667 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Created task run 'calculate_pocket_area-cc18ef62-1' for task 'calculate_pocket_area'\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:33.667 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-1' for task 'calculate_pocket_area'\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.669 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-1' for execution.\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:33.669 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-1' for execution.\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.693 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Created task run 'calculate_pocket_area-cc18ef62-0' for task 'calculate_pocket_area'\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:33.693 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-0' for task 'calculate_pocket_area'\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.695 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-0' for execution.\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:33.695 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-0' for execution.\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.757 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Created task run 'union_dataframes-8a4e3d8f-0' for task 'union_dataframes'\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:33.757 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Created task run 'union_dataframes-8a4e3d8f-0' for task 'union_dataframes'\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.760 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Executing 'union_dataframes-8a4e3d8f-0' immediately...\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:33.760 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Executing 'union_dataframes-8a4e3d8f-0' immediately...\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.888 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:33.888 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:33.974 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:33.974 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.027 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'union_dataframes-8a4e3d8f-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:34.027 | \u001b[36mINFO\u001b[0m    | Task run 'union_dataframes-8a4e3d8f-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.050 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Created task run 'write_csv-386fe2af-0' for task 'write_csv'\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:34.050 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Created task run 'write_csv-386fe2af-0' for task 'write_csv'\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.052 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Executing 'write_csv-386fe2af-0' immediately...\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:34.052 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Executing 'write_csv-386fe2af-0' immediately...\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.155 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:34.155 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.179 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Created task run 'write_csv-386fe2af-1' for task 'write_csv'\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:34.179 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Created task run 'write_csv-386fe2af-1' for task 'write_csv'\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.181 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Executing 'write_csv-386fe2af-1' immediately...\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:34.181 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Executing 'write_csv-386fe2af-1' immediately...\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.234 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:34.234 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.256 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Created task run 'write_csv-386fe2af-2' for task 'write_csv'\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:34.256 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Created task run 'write_csv-386fe2af-2' for task 'write_csv'\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.258 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Executing 'write_csv-386fe2af-2' immediately...\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:34.258 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Executing 'write_csv-386fe2af-2' immediately...\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.340 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-2' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:34.340 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-2' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.367 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Created task run 'write_csv-386fe2af-3' for task 'write_csv'\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:34.367 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Created task run 'write_csv-386fe2af-3' for task 'write_csv'\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.369 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Executing 'write_csv-386fe2af-3' immediately...\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:34.369 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Executing 'write_csv-386fe2af-3' immediately...\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.443 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-3' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:34.443 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-3' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.467 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Created task run 'write_csv-386fe2af-4' for task 'write_csv'\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:34.467 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Created task run 'write_csv-386fe2af-4' for task 'write_csv'\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.469 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Executing 'write_csv-386fe2af-4' immediately...\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:34.469 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Executing 'write_csv-386fe2af-4' immediately...\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.532 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-4' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:34.532 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-4' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:50:34.567 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'amethyst-mole'</span> - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>('All states completed.')\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:50:34.567 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'amethyst-mole'\u001b[0m - Finished in state \u001b[32mCompleted\u001b[0m('All states completed.')\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "_ = main_flow(max_games=3, max_plays=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "d327a87d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_plays_all = pd.read_csv(f\"{DIR}/data/raw/plays.csv\")\n",
+    "df_tracking_display_all = pd.read_csv(f\"{DIR}/data/outputs/tracking_display.csv\")\n",
+    "df_areas_all = pd.read_csv(f\"{DIR}/data/outputs/pocket_areas.csv\")\n",
+    "df_areas_all[\"pocket\"] = df_areas_all[\"pocket\"].apply(literal_eval)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "21daeaa7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3cc19b3e449b4e93871bd449607f7ffd",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "interactive(children=(Dropdown(description='Game ID', options=(2021090900, 2021091200, 2021091201), value=2021…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "create_interactive_play_selector(\n",
+    "    df_plays_all,\n",
+    "    df_tracking_display_all,\n",
+    "    df_areas_all,\n",
+    "    continuous_update=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bafe0987",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/vinesh/visualization_example.ipynb
+++ b/notebooks/vinesh/visualization_example.ipynb
@@ -55,23 +55,13 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/gitpod/.pyenv/versions/3.8.13/lib/python3.8/contextlib.py:120: SAWarning: Skipped unsupported reflection of expression-based index ix_flow_run__coalesce_start_time_expected_start_time_desc\n",
-      "  next(self.gen)\n",
-      "/home/gitpod/.pyenv/versions/3.8.13/lib/python3.8/contextlib.py:120: SAWarning: Skipped unsupported reflection of expression-based index ix_flow_run__coalesce_start_time_expected_start_time_asc\n",
-      "  next(self.gen)\n"
-     ]
-    },
-    {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:06.150 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | prefect.engine - Created flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'energetic-galago'</span> for flow<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\"> 'main-flow'</span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:54.452 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | prefect.engine - Created flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'exotic-bullfinch'</span> for flow<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\"> 'main-flow'</span>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:06.150 | \u001b[36mINFO\u001b[0m    | prefect.engine - Created flow run\u001b[35m 'energetic-galago'\u001b[0m for flow\u001b[1;35m 'main-flow'\u001b[0m\n"
+       "22:47:54.452 | \u001b[36mINFO\u001b[0m    | prefect.engine - Created flow run\u001b[35m 'exotic-bullfinch'\u001b[0m for flow\u001b[1;35m 'main-flow'\u001b[0m\n"
       ]
      },
      "metadata": {},
@@ -80,11 +70,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:06.344 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'energetic-galago'</span> - Created task run 'read_csv-3609c996-0' for task 'read_csv'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:54.594 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'exotic-bullfinch'</span> - Created task run 'read_csv-3609c996-0' for task 'read_csv'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:06.344 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'energetic-galago'\u001b[0m - Created task run 'read_csv-3609c996-0' for task 'read_csv'\n"
+       "22:47:54.594 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'exotic-bullfinch'\u001b[0m - Created task run 'read_csv-3609c996-0' for task 'read_csv'\n"
       ]
      },
      "metadata": {},
@@ -93,11 +83,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:06.347 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'energetic-galago'</span> - Executing 'read_csv-3609c996-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:54.596 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'exotic-bullfinch'</span> - Executing 'read_csv-3609c996-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:06.347 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'energetic-galago'\u001b[0m - Executing 'read_csv-3609c996-0' immediately...\n"
+       "22:47:54.596 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'exotic-bullfinch'\u001b[0m - Executing 'read_csv-3609c996-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -106,11 +96,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:06.637 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'read_csv-3609c996-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:54.902 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'read_csv-3609c996-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:06.637 | \u001b[36mINFO\u001b[0m    | Task run 'read_csv-3609c996-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "22:47:54.902 | \u001b[36mINFO\u001b[0m    | Task run 'read_csv-3609c996-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -119,11 +109,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:06.668 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'energetic-galago'</span> - Created task run 'read_csv-3609c996-1' for task 'read_csv'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:54.926 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'exotic-bullfinch'</span> - Created task run 'read_csv-3609c996-1' for task 'read_csv'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:06.668 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'energetic-galago'\u001b[0m - Created task run 'read_csv-3609c996-1' for task 'read_csv'\n"
+       "22:47:54.926 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'exotic-bullfinch'\u001b[0m - Created task run 'read_csv-3609c996-1' for task 'read_csv'\n"
       ]
      },
      "metadata": {},
@@ -132,11 +122,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:06.670 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'energetic-galago'</span> - Executing 'read_csv-3609c996-1' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:54.928 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'exotic-bullfinch'</span> - Executing 'read_csv-3609c996-1' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:06.670 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'energetic-galago'\u001b[0m - Executing 'read_csv-3609c996-1' immediately...\n"
+       "22:47:54.928 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'exotic-bullfinch'\u001b[0m - Executing 'read_csv-3609c996-1' immediately...\n"
       ]
      },
      "metadata": {},
@@ -145,11 +135,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:06.776 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'read_csv-3609c996-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:55.014 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'read_csv-3609c996-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:06.776 | \u001b[36mINFO\u001b[0m    | Task run 'read_csv-3609c996-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "22:47:55.014 | \u001b[36mINFO\u001b[0m    | Task run 'read_csv-3609c996-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -158,11 +148,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:06.806 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'energetic-galago'</span> - Created task run 'read_csv-3609c996-2' for task 'read_csv'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:55.037 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'exotic-bullfinch'</span> - Created task run 'read_csv-3609c996-2' for task 'read_csv'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:06.806 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'energetic-galago'\u001b[0m - Created task run 'read_csv-3609c996-2' for task 'read_csv'\n"
+       "22:47:55.037 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'exotic-bullfinch'\u001b[0m - Created task run 'read_csv-3609c996-2' for task 'read_csv'\n"
       ]
      },
      "metadata": {},
@@ -171,11 +161,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:06.809 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'energetic-galago'</span> - Executing 'read_csv-3609c996-2' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:55.039 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'exotic-bullfinch'</span> - Executing 'read_csv-3609c996-2' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:06.809 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'energetic-galago'\u001b[0m - Executing 'read_csv-3609c996-2' immediately...\n"
+       "22:47:55.039 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'exotic-bullfinch'\u001b[0m - Executing 'read_csv-3609c996-2' immediately...\n"
       ]
      },
      "metadata": {},
@@ -184,11 +174,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:08.912 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'read_csv-3609c996-2' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:57.067 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'read_csv-3609c996-2' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:08.912 | \u001b[36mINFO\u001b[0m    | Task run 'read_csv-3609c996-2' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "22:47:57.067 | \u001b[36mINFO\u001b[0m    | Task run 'read_csv-3609c996-2' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -197,11 +187,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:10.244 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'energetic-galago'</span> - Created task run 'transform_to_tracking_display-0c78dc49-0' for task 'transform_to_tracking_display'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:58.035 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'exotic-bullfinch'</span> - Created task run 'transform_to_tracking_display-0c78dc49-0' for task 'transform_to_tracking_display'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:10.244 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'energetic-galago'\u001b[0m - Created task run 'transform_to_tracking_display-0c78dc49-0' for task 'transform_to_tracking_display'\n"
+       "22:47:58.035 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'exotic-bullfinch'\u001b[0m - Created task run 'transform_to_tracking_display-0c78dc49-0' for task 'transform_to_tracking_display'\n"
       ]
      },
      "metadata": {},
@@ -210,11 +200,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:10.247 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'energetic-galago'</span> - Executing 'transform_to_tracking_display-0c78dc49-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:58.037 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'exotic-bullfinch'</span> - Executing 'transform_to_tracking_display-0c78dc49-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:10.247 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'energetic-galago'\u001b[0m - Executing 'transform_to_tracking_display-0c78dc49-0' immediately...\n"
+       "22:47:58.037 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'exotic-bullfinch'\u001b[0m - Executing 'transform_to_tracking_display-0c78dc49-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -223,11 +213,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:10.376 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'transform_to_tracking_display-0c78dc49-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:58.144 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'transform_to_tracking_display-0c78dc49-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:10.376 | \u001b[36mINFO\u001b[0m    | Task run 'transform_to_tracking_display-0c78dc49-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "22:47:58.144 | \u001b[36mINFO\u001b[0m    | Task run 'transform_to_tracking_display-0c78dc49-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -236,11 +226,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:10.414 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'energetic-galago'</span> - Created task run 'transform_to_frames-3446c324-0' for task 'transform_to_frames'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:58.170 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'exotic-bullfinch'</span> - Created task run 'transform_to_frames-3446c324-0' for task 'transform_to_frames'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:10.414 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'energetic-galago'\u001b[0m - Created task run 'transform_to_frames-3446c324-0' for task 'transform_to_frames'\n"
+       "22:47:58.170 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'exotic-bullfinch'\u001b[0m - Created task run 'transform_to_frames-3446c324-0' for task 'transform_to_frames'\n"
       ]
      },
      "metadata": {},
@@ -249,11 +239,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:10.416 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'energetic-galago'</span> - Executing 'transform_to_frames-3446c324-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:58.172 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'exotic-bullfinch'</span> - Executing 'transform_to_frames-3446c324-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:10.416 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'energetic-galago'\u001b[0m - Executing 'transform_to_frames-3446c324-0' immediately...\n"
+       "22:47:58.172 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'exotic-bullfinch'\u001b[0m - Executing 'transform_to_frames-3446c324-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -262,11 +252,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:10.554 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'transform_to_frames-3446c324-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:58.289 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'transform_to_frames-3446c324-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:10.554 | \u001b[36mINFO\u001b[0m    | Task run 'transform_to_frames-3446c324-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "22:47:58.289 | \u001b[36mINFO\u001b[0m    | Task run 'transform_to_frames-3446c324-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -275,11 +265,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:10.581 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'energetic-galago'</span> - Created task run 'transform_to_records_per_frame-823b8998-0' for task 'transform_to_records_per_frame'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:58.311 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'exotic-bullfinch'</span> - Created task run 'transform_to_records_per_frame-823b8998-0' for task 'transform_to_records_per_frame'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:10.581 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'energetic-galago'\u001b[0m - Created task run 'transform_to_records_per_frame-823b8998-0' for task 'transform_to_records_per_frame'\n"
+       "22:47:58.311 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'exotic-bullfinch'\u001b[0m - Created task run 'transform_to_records_per_frame-823b8998-0' for task 'transform_to_records_per_frame'\n"
       ]
      },
      "metadata": {},
@@ -288,11 +278,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:10.583 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'energetic-galago'</span> - Executing 'transform_to_records_per_frame-823b8998-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:58.313 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'exotic-bullfinch'</span> - Executing 'transform_to_records_per_frame-823b8998-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:10.583 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'energetic-galago'\u001b[0m - Executing 'transform_to_records_per_frame-823b8998-0' immediately...\n"
+       "22:47:58.313 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'exotic-bullfinch'\u001b[0m - Executing 'transform_to_records_per_frame-823b8998-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -301,11 +291,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:10.960 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'transform_to_records_per_frame-823b8998-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:58.655 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'transform_to_records_per_frame-823b8998-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:10.960 | \u001b[36mINFO\u001b[0m    | Task run 'transform_to_records_per_frame-823b8998-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "22:47:58.655 | \u001b[36mINFO\u001b[0m    | Task run 'transform_to_records_per_frame-823b8998-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -314,11 +304,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:11.004 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'energetic-galago'</span> - Created task run 'calculate_pocket_area-cc18ef62-1' for task 'calculate_pocket_area'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:58.692 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'exotic-bullfinch'</span> - Created task run 'calculate_pocket_area-cc18ef62-1' for task 'calculate_pocket_area'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:11.004 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'energetic-galago'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-1' for task 'calculate_pocket_area'\n"
+       "22:47:58.692 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'exotic-bullfinch'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-1' for task 'calculate_pocket_area'\n"
       ]
      },
      "metadata": {},
@@ -327,11 +317,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:11.006 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'energetic-galago'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-1' for execution.\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:58.694 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'exotic-bullfinch'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-1' for execution.\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:11.006 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'energetic-galago'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-1' for execution.\n"
+       "22:47:58.694 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'exotic-bullfinch'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-1' for execution.\n"
       ]
      },
      "metadata": {},
@@ -340,11 +330,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:11.029 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'energetic-galago'</span> - Created task run 'calculate_pocket_area-cc18ef62-0' for task 'calculate_pocket_area'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:58.717 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'exotic-bullfinch'</span> - Created task run 'calculate_pocket_area-cc18ef62-0' for task 'calculate_pocket_area'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:11.029 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'energetic-galago'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-0' for task 'calculate_pocket_area'\n"
+       "22:47:58.717 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'exotic-bullfinch'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-0' for task 'calculate_pocket_area'\n"
       ]
      },
      "metadata": {},
@@ -353,11 +343,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:11.032 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'energetic-galago'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-0' for execution.\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:58.719 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'exotic-bullfinch'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-0' for execution.\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:11.032 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'energetic-galago'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-0' for execution.\n"
+       "22:47:58.719 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'exotic-bullfinch'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-0' for execution.\n"
       ]
      },
      "metadata": {},
@@ -366,11 +356,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:11.098 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'energetic-galago'</span> - Created task run 'union_dataframes-8a4e3d8f-0' for task 'union_dataframes'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:58.835 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'exotic-bullfinch'</span> - Created task run 'union_dataframes-8a4e3d8f-0' for task 'union_dataframes'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:11.098 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'energetic-galago'\u001b[0m - Created task run 'union_dataframes-8a4e3d8f-0' for task 'union_dataframes'\n"
+       "22:47:58.835 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'exotic-bullfinch'\u001b[0m - Created task run 'union_dataframes-8a4e3d8f-0' for task 'union_dataframes'\n"
       ]
      },
      "metadata": {},
@@ -379,11 +369,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:11.102 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'energetic-galago'</span> - Executing 'union_dataframes-8a4e3d8f-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:58.838 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'exotic-bullfinch'</span> - Executing 'union_dataframes-8a4e3d8f-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:11.102 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'energetic-galago'\u001b[0m - Executing 'union_dataframes-8a4e3d8f-0' immediately...\n"
+       "22:47:58.838 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'exotic-bullfinch'\u001b[0m - Executing 'union_dataframes-8a4e3d8f-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -392,11 +382,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:11.221 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:58.861 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:11.221 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "22:47:58.861 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -405,11 +395,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:11.318 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:58.949 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:11.318 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "22:47:58.949 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -418,11 +408,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:11.379 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'union_dataframes-8a4e3d8f-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:58.999 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'union_dataframes-8a4e3d8f-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:11.379 | \u001b[36mINFO\u001b[0m    | Task run 'union_dataframes-8a4e3d8f-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "22:47:58.999 | \u001b[36mINFO\u001b[0m    | Task run 'union_dataframes-8a4e3d8f-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -431,11 +421,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:11.410 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'energetic-galago'</span> - Created task run 'write_csv-386fe2af-0' for task 'write_csv'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:59.023 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'exotic-bullfinch'</span> - Created task run 'write_csv-386fe2af-0' for task 'write_csv'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:11.410 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'energetic-galago'\u001b[0m - Created task run 'write_csv-386fe2af-0' for task 'write_csv'\n"
+       "22:47:59.023 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'exotic-bullfinch'\u001b[0m - Created task run 'write_csv-386fe2af-0' for task 'write_csv'\n"
       ]
      },
      "metadata": {},
@@ -444,11 +434,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:11.412 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'energetic-galago'</span> - Executing 'write_csv-386fe2af-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:59.025 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'exotic-bullfinch'</span> - Executing 'write_csv-386fe2af-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:11.412 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'energetic-galago'\u001b[0m - Executing 'write_csv-386fe2af-0' immediately...\n"
+       "22:47:59.025 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'exotic-bullfinch'\u001b[0m - Executing 'write_csv-386fe2af-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -457,11 +447,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:11.526 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:59.119 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:11.526 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "22:47:59.119 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -470,11 +460,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:11.554 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'energetic-galago'</span> - Created task run 'write_csv-386fe2af-1' for task 'write_csv'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:59.140 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'exotic-bullfinch'</span> - Created task run 'write_csv-386fe2af-1' for task 'write_csv'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:11.554 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'energetic-galago'\u001b[0m - Created task run 'write_csv-386fe2af-1' for task 'write_csv'\n"
+       "22:47:59.140 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'exotic-bullfinch'\u001b[0m - Created task run 'write_csv-386fe2af-1' for task 'write_csv'\n"
       ]
      },
      "metadata": {},
@@ -483,11 +473,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:11.556 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'energetic-galago'</span> - Executing 'write_csv-386fe2af-1' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:59.142 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'exotic-bullfinch'</span> - Executing 'write_csv-386fe2af-1' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:11.556 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'energetic-galago'\u001b[0m - Executing 'write_csv-386fe2af-1' immediately...\n"
+       "22:47:59.142 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'exotic-bullfinch'\u001b[0m - Executing 'write_csv-386fe2af-1' immediately...\n"
       ]
      },
      "metadata": {},
@@ -496,11 +486,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:11.658 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:59.191 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:11.658 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "22:47:59.191 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -509,11 +499,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:11.689 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'energetic-galago'</span> - Created task run 'write_csv-386fe2af-2' for task 'write_csv'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:59.212 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'exotic-bullfinch'</span> - Created task run 'write_csv-386fe2af-2' for task 'write_csv'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:11.689 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'energetic-galago'\u001b[0m - Created task run 'write_csv-386fe2af-2' for task 'write_csv'\n"
+       "22:47:59.212 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'exotic-bullfinch'\u001b[0m - Created task run 'write_csv-386fe2af-2' for task 'write_csv'\n"
       ]
      },
      "metadata": {},
@@ -522,11 +512,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:11.691 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'energetic-galago'</span> - Executing 'write_csv-386fe2af-2' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:59.214 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'exotic-bullfinch'</span> - Executing 'write_csv-386fe2af-2' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:11.691 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'energetic-galago'\u001b[0m - Executing 'write_csv-386fe2af-2' immediately...\n"
+       "22:47:59.214 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'exotic-bullfinch'\u001b[0m - Executing 'write_csv-386fe2af-2' immediately...\n"
       ]
      },
      "metadata": {},
@@ -535,11 +525,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:11.778 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-2' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:59.286 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-2' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:11.778 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-2' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "22:47:59.286 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-2' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -548,11 +538,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:11.809 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'energetic-galago'</span> - Created task run 'write_csv-386fe2af-3' for task 'write_csv'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:59.310 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'exotic-bullfinch'</span> - Created task run 'write_csv-386fe2af-3' for task 'write_csv'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:11.809 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'energetic-galago'\u001b[0m - Created task run 'write_csv-386fe2af-3' for task 'write_csv'\n"
+       "22:47:59.310 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'exotic-bullfinch'\u001b[0m - Created task run 'write_csv-386fe2af-3' for task 'write_csv'\n"
       ]
      },
      "metadata": {},
@@ -561,11 +551,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:11.811 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'energetic-galago'</span> - Executing 'write_csv-386fe2af-3' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:59.311 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'exotic-bullfinch'</span> - Executing 'write_csv-386fe2af-3' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:11.811 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'energetic-galago'\u001b[0m - Executing 'write_csv-386fe2af-3' immediately...\n"
+       "22:47:59.311 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'exotic-bullfinch'\u001b[0m - Executing 'write_csv-386fe2af-3' immediately...\n"
       ]
      },
      "metadata": {},
@@ -574,11 +564,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:11.886 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-3' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:59.383 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-3' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:11.886 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-3' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "22:47:59.383 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-3' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -587,11 +577,50 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">04:59:11.929 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'energetic-galago'</span> - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>('All states completed.')\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:59.408 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'exotic-bullfinch'</span> - Created task run 'write_csv-386fe2af-4' for task 'write_csv'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "04:59:11.929 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'energetic-galago'\u001b[0m - Finished in state \u001b[32mCompleted\u001b[0m('All states completed.')\n"
+       "22:47:59.408 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'exotic-bullfinch'\u001b[0m - Created task run 'write_csv-386fe2af-4' for task 'write_csv'\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:59.410 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'exotic-bullfinch'</span> - Executing 'write_csv-386fe2af-4' immediately...\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:47:59.410 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'exotic-bullfinch'\u001b[0m - Executing 'write_csv-386fe2af-4' immediately...\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:59.472 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-4' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:47:59.472 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-4' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">22:47:59.512 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'exotic-bullfinch'</span> - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>('All states completed.')\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "22:47:59.512 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'exotic-bullfinch'\u001b[0m - Finished in state \u001b[32mCompleted\u001b[0m('All states completed.')\n"
       ]
      },
      "metadata": {},
@@ -617,7 +646,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 6,
    "id": "a8b17aa2",
    "metadata": {
     "scrolled": false
@@ -626,7 +655,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "768f9fb549664dc3ac0857cfd04780cb",
+       "model_id": "aed68c57e6a546ae99705f8b43533010",
        "version_major": 2,
        "version_minor": 0
       },

--- a/src/pipeline/flows/main.py
+++ b/src/pipeline/flows/main.py
@@ -2,11 +2,13 @@ from prefect import flow, task, unmapped
 
 from src.metrics.pocket_area.all import POCKET_AREA_METHODS
 from src.pipeline.tasks import (
+    align_tracking_data,
     calculate_pocket_area,
     clean_event_data,
     limit_by_child_keys,
     limit_by_keys,
     read_csv,
+    rotate_tracking_data,
     transform_to_frames,
     transform_to_records_per_frame,
     transform_to_tracking_display,
@@ -34,14 +36,16 @@ def main_flow(**kwargs):
     df_tracking_games = limit_by_keys(
         df_tracking_all, keys=["gameId"], n=max_games
     )
-    df_tracking = limit_by_child_keys(
+    df_tracking_limited = limit_by_child_keys(
         df_tracking_games,
         parent_keys=["gameId"],
         child_keys=["playId"],
         n=max_plays,
     )
 
-    # TODO(vinesh): Align, rotate, and orient tracking data.
+    # Align and rotate tracking data.
+    df_tracking_aligned = align_tracking_data(df_tracking_limited)
+    df_tracking = rotate_tracking_data(df_tracking_aligned)
 
     # Clean event data.
     df_events = clean_event_data(df_tracking)

--- a/src/pipeline/tasks/tracking.py
+++ b/src/pipeline/tasks/tracking.py
@@ -6,6 +6,77 @@ from src.pipeline.tasks.constants import (
     TRACKING_PRIMARY_KEY,
 )
 
+FIELD_LENGTH = 120
+FIELD_WIDTH = 53 + (1.0 / 3.0)
+
+
+def align_coordinates(direction: str, x: float, y: float) -> pd.Series:
+    """
+    Returns a new row with three columns so that the coordinates and play
+    direction always go right.
+    """
+    if direction == "right":
+        new_x = x
+        new_y = y
+    elif direction == "left":
+        # Rotate coordinates by 180 degrees, then shift by the length and width
+        # of the football field.
+        new_x = (-1 * x) + FIELD_LENGTH
+        new_y = (-1 * y) + FIELD_WIDTH
+    else:
+        raise ValueError(f"Invalid direction: {direction}")
+
+    new_direction = "right"
+    return pd.Series([new_direction, new_x, new_y])
+
+
+def rotate_coordinates(x: float, y: float) -> pd.Series:
+    """
+    Returns a new row with two columns so that the coordinates have the length
+    of the field on the y-axis and the width of the field on the x-axis. On the
+    x-axis, the left sideline is 0 and the right sideline is 53.333. On the
+    y-axis, the bottom endline is 0 and the top endline is 120.
+    """
+    # x-coordinate takes the value of the y-coordinate, but also needs to reset
+    # the axis to run from 0 to 53.333 instead of from 53.333 to 0.
+    new_x = FIELD_WIDTH - y
+    # y-coordinate just takes the value of the x-coordinate.
+    new_y = x
+    return pd.Series([new_x, new_y])
+
+
+def align_tracking_data(df_tracking: pd.DataFrame) -> pd.DataFrame:
+    """
+    Aligns tracking data so that all plays have `playDirection = right`.
+    """
+    # Copy input DataFrame.
+    df = pd.DataFrame(df_tracking)
+    df[["playDirection", "x", "y"]] = df.apply(
+        lambda row: align_coordinates(
+            direction=row["playDirection"],
+            x=row["x"],
+            y=row["y"],
+        ),
+        axis=1,
+    )
+    return df
+
+
+def rotate_tracking_data(df_tracking: pd.DataFrame) -> pd.DataFrame:
+    """
+    Rotates tracking data so that the x-axis is the width of the football field
+    and the y-axis is the length of the football field.
+
+    Tracking data should already be aligned.
+    """
+    # Copy input DataFrame.
+    df = pd.DataFrame(df_tracking)
+    df[["x", "y"]] = df.apply(
+        lambda row: rotate_coordinates(x=row["x"], y=row["y"]),
+        axis=1,
+    )
+    return df
+
 
 def transform_to_tracking_display(
     df_tracking: pd.DataFrame, df_plays: pd.DataFrame, df_pff: pd.DataFrame

--- a/src/pipeline/tasks/tracking_test.py
+++ b/src/pipeline/tasks/tracking_test.py
@@ -18,17 +18,23 @@ def approx_one_decimal(expected: float):
 def test_align_tracking_data():
     df_tracking = pd.DataFrame(
         [
-            {"playDirection": "right", "x": 30, "y": 50},
+            {"playDirection": "right", "x": 30, "y": 50, "o": 90, "dir": 0},
             # After alignment, the coordinates should be:
             # x: 80 yards from left endline -> 40 yards from left endline
             # y: 10 yards from bottom sideline -> 43.3 yards from bottom sideline
-            {"playDirection": "left", "x": 80, "y": 10},
+            {"playDirection": "left", "x": 80, "y": 10, "o": 270, "dir": 180},
         ]
     )
     actual = align_tracking_data(df_tracking)
     expected = [
-        {"playDirection": "right", "x": 30, "y": 50},
-        {"playDirection": "right", "x": 40, "y": approx_one_decimal(43.3)},
+        {"playDirection": "right", "x": 30, "y": 50, "o": 90, "dir": 0},
+        {
+            "playDirection": "right",
+            "x": 40,
+            "y": approx_one_decimal(43.3),
+            "o": 90,
+            "dir": 0,
+        },
     ]
     assert actual.to_dict(orient="records") == expected
 
@@ -36,13 +42,25 @@ def test_align_tracking_data():
 def test_rotate_tracking_data():
     df_tracking = pd.DataFrame(
         [
-            {"playDirection": "right", "x": 30, "y": 50},
-            {"playDirection": "right", "x": 30, "y": 3},
+            {"playDirection": "right", "x": 30, "y": 50, "o": 90, "dir": 0},
+            {"playDirection": "right", "x": 30, "y": 3, "o": 180, "dir": 315},
         ]
     )
     actual = rotate_tracking_data(df_tracking)
     expected = [
-        {"playDirection": "right", "x": approx_one_decimal(3.3), "y": 30},
-        {"playDirection": "right", "x": approx_one_decimal(50.3), "y": 30},
+        {
+            "playDirection": "right",
+            "x": approx_one_decimal(3.3),
+            "y": 30,
+            "o": 0,
+            "dir": 270,
+        },
+        {
+            "playDirection": "right",
+            "x": approx_one_decimal(50.3),
+            "y": 30,
+            "o": 90,
+            "dir": 225,
+        },
     ]
     assert actual.to_dict(orient="records") == expected

--- a/src/pipeline/tasks/tracking_test.py
+++ b/src/pipeline/tasks/tracking_test.py
@@ -1,0 +1,48 @@
+import pandas as pd
+import pytest
+
+from src.pipeline.tasks.tracking import (
+    align_tracking_data,
+    rotate_tracking_data,
+)
+
+
+def approx_one_decimal(expected: float):
+    """
+    Test helper function to check if another float is approximately equal to the
+    given expected float, at a tolerance of +/- 0.1.
+    """
+    return pytest.approx(expected, abs=1e-1)
+
+
+def test_align_tracking_data():
+    df_tracking = pd.DataFrame(
+        [
+            {"playDirection": "right", "x": 30, "y": 50},
+            # After alignment, the coordinates should be:
+            # x: 80 yards from left endline -> 40 yards from left endline
+            # y: 10 yards from bottom sideline -> 43.3 yards from bottom sideline
+            {"playDirection": "left", "x": 80, "y": 10},
+        ]
+    )
+    actual = align_tracking_data(df_tracking)
+    expected = [
+        {"playDirection": "right", "x": 30, "y": 50},
+        {"playDirection": "right", "x": 40, "y": approx_one_decimal(43.3)},
+    ]
+    assert actual.to_dict(orient="records") == expected
+
+
+def test_rotate_tracking_data():
+    df_tracking = pd.DataFrame(
+        [
+            {"playDirection": "right", "x": 30, "y": 50},
+            {"playDirection": "right", "x": 30, "y": 3},
+        ]
+    )
+    actual = rotate_tracking_data(df_tracking)
+    expected = [
+        {"playDirection": "right", "x": approx_one_decimal(3.3), "y": 30},
+        {"playDirection": "right", "x": approx_one_decimal(50.3), "y": 30},
+    ]
+    assert actual.to_dict(orient="records") == expected


### PR DESCRIPTION
## Summary

- Aligns tracking data so that all plays have play direction going to the right.
- Rotate aligned tracking data so that all plays have y as endzone-to-endzone and x as sideline-to-sideline.

I decided not to bring in the normalization, which centers the ball snap as (0, 0), because I thought it would be easier to keep the yard lines.

In order to check whether the passer has left the area that officials will consider the pocket, we can still compare the ball snap point to the passer position.

I checked visually to make sure that the coordinates and angles have been rotated correctly on one right-facing play and one left-facing play. Notice that the pocket area values have not changed because they do not depend on rotation. And that this approach works independently of pocket area method.

## Example Right-Facing Play

### Before

<img width="900" alt="Screen Shot 2022-12-31 at 4 48 18 PM" src="https://user-images.githubusercontent.com/11896652/210157411-45f84bd0-8f80-4200-bb26-d7b39a240615.png">

### After

<img width="900" alt="Screen Shot 2022-12-31 at 5 11 10 PM" src="https://user-images.githubusercontent.com/11896652/210157413-cd96f743-2a20-4a73-950e-b785417606b2.png">

## Example Left-Facing Play

### Before

<img width="900" alt="Screen Shot 2022-12-31 at 4 48 55 PM" src="https://user-images.githubusercontent.com/11896652/210157412-5b905ed6-28c5-45b0-a172-da84a57ec6ae.png">

### After

<img width="900" alt="Screen Shot 2022-12-31 at 5 11 23 PM" src="https://user-images.githubusercontent.com/11896652/210157414-3f71ea83-9e70-4006-9e3d-cdf4430b694b.png">
