### PR TITLE
Refactor codebase for compatibility with Python 3.7.12 on Kaggle.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.0.3
+# 0.0.8
 
 Versions between this and 0.0.1 are testing the package release process.
 

--- a/notebooks/vinesh/run_pipeline.ipynb
+++ b/notebooks/vinesh/run_pipeline.ipynb
@@ -53,11 +53,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:19.253 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | prefect.engine - Created flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> for flow<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\"> 'main-flow'</span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:17.803 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | prefect.engine - Created flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> for flow<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\"> 'main-flow'</span>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:19.253 | \u001b[36mINFO\u001b[0m    | prefect.engine - Created flow run\u001b[35m 'elegant-mule'\u001b[0m for flow\u001b[1;35m 'main-flow'\u001b[0m\n"
+       "20:21:17.803 | \u001b[36mINFO\u001b[0m    | prefect.engine - Created flow run\u001b[35m 'little-seagull'\u001b[0m for flow\u001b[1;35m 'main-flow'\u001b[0m\n"
       ]
      },
      "metadata": {},
@@ -66,11 +66,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:19.418 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Created task run 'read_csv-3609c996-0' for task 'read_csv'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:17.991 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'read_csv-3609c996-0' for task 'read_csv'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:19.418 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Created task run 'read_csv-3609c996-0' for task 'read_csv'\n"
+       "20:21:17.991 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'read_csv-3609c996-0' for task 'read_csv'\n"
       ]
      },
      "metadata": {},
@@ -79,11 +79,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:19.421 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Executing 'read_csv-3609c996-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:17.995 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'read_csv-3609c996-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:19.421 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Executing 'read_csv-3609c996-0' immediately...\n"
+       "20:21:17.995 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'read_csv-3609c996-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -92,11 +92,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:19.838 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'read_csv-3609c996-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:18.257 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'read_csv-3609c996-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:19.838 | \u001b[36mINFO\u001b[0m    | Task run 'read_csv-3609c996-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:21:18.257 | \u001b[36mINFO\u001b[0m    | Task run 'read_csv-3609c996-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -105,11 +105,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:19.865 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Created task run 'read_csv-3609c996-1' for task 'read_csv'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:18.286 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'read_csv-3609c996-1' for task 'read_csv'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:19.865 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Created task run 'read_csv-3609c996-1' for task 'read_csv'\n"
+       "20:21:18.286 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'read_csv-3609c996-1' for task 'read_csv'\n"
       ]
      },
      "metadata": {},
@@ -118,11 +118,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:19.867 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Executing 'read_csv-3609c996-1' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:18.289 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'read_csv-3609c996-1' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:19.867 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Executing 'read_csv-3609c996-1' immediately...\n"
+       "20:21:18.289 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'read_csv-3609c996-1' immediately...\n"
       ]
      },
      "metadata": {},
@@ -131,11 +131,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:19.966 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'read_csv-3609c996-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:18.395 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'read_csv-3609c996-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:19.966 | \u001b[36mINFO\u001b[0m    | Task run 'read_csv-3609c996-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:21:18.395 | \u001b[36mINFO\u001b[0m    | Task run 'read_csv-3609c996-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -144,11 +144,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:19.994 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Created task run 'read_tracking_data-e2eae939-0' for task 'read_tracking_data'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:18.429 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'read_tracking_data-e2eae939-0' for task 'read_tracking_data'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:19.994 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Created task run 'read_tracking_data-e2eae939-0' for task 'read_tracking_data'\n"
+       "20:21:18.429 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'read_tracking_data-e2eae939-0' for task 'read_tracking_data'\n"
       ]
      },
      "metadata": {},
@@ -157,11 +157,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:19.996 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Executing 'read_tracking_data-e2eae939-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:18.432 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'read_tracking_data-e2eae939-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:19.996 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Executing 'read_tracking_data-e2eae939-0' immediately...\n"
+       "20:21:18.432 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'read_tracking_data-e2eae939-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -170,11 +170,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:24.819 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'read_tracking_data-e2eae939-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:22.129 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'read_tracking_data-e2eae939-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:24.819 | \u001b[36mINFO\u001b[0m    | Task run 'read_tracking_data-e2eae939-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:21:22.129 | \u001b[36mINFO\u001b[0m    | Task run 'read_tracking_data-e2eae939-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -183,11 +183,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:24.851 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Created task run 'limit_by_child_keys-4238f776-0' for task 'limit_by_child_keys'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:22.154 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'limit_by_child_keys-4238f776-0' for task 'limit_by_child_keys'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:24.851 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Created task run 'limit_by_child_keys-4238f776-0' for task 'limit_by_child_keys'\n"
+       "20:21:22.154 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'limit_by_child_keys-4238f776-0' for task 'limit_by_child_keys'\n"
       ]
      },
      "metadata": {},
@@ -196,11 +196,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:24.853 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Executing 'limit_by_child_keys-4238f776-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:22.156 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'limit_by_child_keys-4238f776-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:24.853 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Executing 'limit_by_child_keys-4238f776-0' immediately...\n"
+       "20:21:22.156 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'limit_by_child_keys-4238f776-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -209,11 +209,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:24.921 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'limit_by_child_keys-4238f776-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:22.219 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'limit_by_child_keys-4238f776-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:24.921 | \u001b[36mINFO\u001b[0m    | Task run 'limit_by_child_keys-4238f776-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:21:22.219 | \u001b[36mINFO\u001b[0m    | Task run 'limit_by_child_keys-4238f776-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -222,11 +222,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:24.950 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Created task run 'limit_by_child_keys-4238f776-1' for task 'limit_by_child_keys'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:22.247 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'limit_by_child_keys-4238f776-1' for task 'limit_by_child_keys'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:24.950 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Created task run 'limit_by_child_keys-4238f776-1' for task 'limit_by_child_keys'\n"
+       "20:21:22.247 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'limit_by_child_keys-4238f776-1' for task 'limit_by_child_keys'\n"
       ]
      },
      "metadata": {},
@@ -235,11 +235,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:24.953 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Executing 'limit_by_child_keys-4238f776-1' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:22.249 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'limit_by_child_keys-4238f776-1' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:24.953 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Executing 'limit_by_child_keys-4238f776-1' immediately...\n"
+       "20:21:22.249 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'limit_by_child_keys-4238f776-1' immediately...\n"
       ]
      },
      "metadata": {},
@@ -248,11 +248,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:25.018 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'limit_by_child_keys-4238f776-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:22.318 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'limit_by_child_keys-4238f776-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:25.018 | \u001b[36mINFO\u001b[0m    | Task run 'limit_by_child_keys-4238f776-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:21:22.318 | \u001b[36mINFO\u001b[0m    | Task run 'limit_by_child_keys-4238f776-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -261,11 +261,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:25.045 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Created task run 'align_tracking_data-ea7afe30-0' for task 'align_tracking_data'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:22.348 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'align_tracking_data-ea7afe30-0' for task 'align_tracking_data'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:25.045 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Created task run 'align_tracking_data-ea7afe30-0' for task 'align_tracking_data'\n"
+       "20:21:22.348 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'align_tracking_data-ea7afe30-0' for task 'align_tracking_data'\n"
       ]
      },
      "metadata": {},
@@ -274,11 +274,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:25.047 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Executing 'align_tracking_data-ea7afe30-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:22.350 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'align_tracking_data-ea7afe30-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:25.047 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Executing 'align_tracking_data-ea7afe30-0' immediately...\n"
+       "20:21:22.350 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'align_tracking_data-ea7afe30-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -287,11 +287,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:26.899 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'align_tracking_data-ea7afe30-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:22.689 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'align_tracking_data-ea7afe30-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:26.899 | \u001b[36mINFO\u001b[0m    | Task run 'align_tracking_data-ea7afe30-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:21:22.689 | \u001b[36mINFO\u001b[0m    | Task run 'align_tracking_data-ea7afe30-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -300,11 +300,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:26.931 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Created task run 'rotate_tracking_data-13ea6cce-0' for task 'rotate_tracking_data'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:22.718 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'rotate_tracking_data-13ea6cce-0' for task 'rotate_tracking_data'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:26.931 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Created task run 'rotate_tracking_data-13ea6cce-0' for task 'rotate_tracking_data'\n"
+       "20:21:22.718 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'rotate_tracking_data-13ea6cce-0' for task 'rotate_tracking_data'\n"
       ]
      },
      "metadata": {},
@@ -313,11 +313,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:26.933 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Executing 'rotate_tracking_data-13ea6cce-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:22.719 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'rotate_tracking_data-13ea6cce-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:26.933 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Executing 'rotate_tracking_data-13ea6cce-0' immediately...\n"
+       "20:21:22.719 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'rotate_tracking_data-13ea6cce-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -326,11 +326,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:27.069 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'rotate_tracking_data-13ea6cce-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:22.843 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'rotate_tracking_data-13ea6cce-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:27.069 | \u001b[36mINFO\u001b[0m    | Task run 'rotate_tracking_data-13ea6cce-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:21:22.843 | \u001b[36mINFO\u001b[0m    | Task run 'rotate_tracking_data-13ea6cce-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -339,11 +339,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:27.105 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Created task run 'get_passer_out_of_pocket-98072e46-0' for task 'get_passer_out_of_pocket'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:22.878 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'get_passer_out_of_pocket-98072e46-0' for task 'get_passer_out_of_pocket'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:27.105 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Created task run 'get_passer_out_of_pocket-98072e46-0' for task 'get_passer_out_of_pocket'\n"
+       "20:21:22.878 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'get_passer_out_of_pocket-98072e46-0' for task 'get_passer_out_of_pocket'\n"
       ]
      },
      "metadata": {},
@@ -352,11 +352,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:27.107 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Executing 'get_passer_out_of_pocket-98072e46-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:22.881 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'get_passer_out_of_pocket-98072e46-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:27.107 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Executing 'get_passer_out_of_pocket-98072e46-0' immediately...\n"
+       "20:21:22.881 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'get_passer_out_of_pocket-98072e46-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -365,11 +365,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:32.118 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'get_passer_out_of_pocket-98072e46-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:27.741 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'get_passer_out_of_pocket-98072e46-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:32.118 | \u001b[36mINFO\u001b[0m    | Task run 'get_passer_out_of_pocket-98072e46-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:21:27.741 | \u001b[36mINFO\u001b[0m    | Task run 'get_passer_out_of_pocket-98072e46-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -378,11 +378,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:32.152 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Created task run 'clean_event_data-657c8302-0' for task 'clean_event_data'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:27.766 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'clean_event_data-657c8302-0' for task 'clean_event_data'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:32.152 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Created task run 'clean_event_data-657c8302-0' for task 'clean_event_data'\n"
+       "20:21:27.766 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'clean_event_data-657c8302-0' for task 'clean_event_data'\n"
       ]
      },
      "metadata": {},
@@ -391,11 +391,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:32.154 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Executing 'clean_event_data-657c8302-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:27.769 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'clean_event_data-657c8302-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:32.154 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Executing 'clean_event_data-657c8302-0' immediately...\n"
+       "20:21:27.769 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'clean_event_data-657c8302-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -404,11 +404,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:33.902 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'clean_event_data-657c8302-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:29.379 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'clean_event_data-657c8302-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:33.902 | \u001b[36mINFO\u001b[0m    | Task run 'clean_event_data-657c8302-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:21:29.379 | \u001b[36mINFO\u001b[0m    | Task run 'clean_event_data-657c8302-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -417,11 +417,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:33.935 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Created task run 'get_pocket_eligibility-6d653879-0' for task 'get_pocket_eligibility'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:29.406 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'get_pocket_eligibility-6d653879-0' for task 'get_pocket_eligibility'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:33.935 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Created task run 'get_pocket_eligibility-6d653879-0' for task 'get_pocket_eligibility'\n"
+       "20:21:29.406 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'get_pocket_eligibility-6d653879-0' for task 'get_pocket_eligibility'\n"
       ]
      },
      "metadata": {},
@@ -430,11 +430,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:33.939 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Executing 'get_pocket_eligibility-6d653879-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:29.408 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'get_pocket_eligibility-6d653879-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:33.939 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Executing 'get_pocket_eligibility-6d653879-0' immediately...\n"
+       "20:21:29.408 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'get_pocket_eligibility-6d653879-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -443,11 +443,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:34.130 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'get_pocket_eligibility-6d653879-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:29.583 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'get_pocket_eligibility-6d653879-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:34.130 | \u001b[36mINFO\u001b[0m    | Task run 'get_pocket_eligibility-6d653879-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:21:29.583 | \u001b[36mINFO\u001b[0m    | Task run 'get_pocket_eligibility-6d653879-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -456,11 +456,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:34.161 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Created task run 'augment_tracking_events-342a9dc3-0' for task 'augment_tracking_events'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:29.610 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'augment_tracking_events-342a9dc3-0' for task 'augment_tracking_events'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:34.161 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Created task run 'augment_tracking_events-342a9dc3-0' for task 'augment_tracking_events'\n"
+       "20:21:29.610 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'augment_tracking_events-342a9dc3-0' for task 'augment_tracking_events'\n"
       ]
      },
      "metadata": {},
@@ -469,11 +469,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:34.163 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Executing 'augment_tracking_events-342a9dc3-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:29.612 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'augment_tracking_events-342a9dc3-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:34.163 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Executing 'augment_tracking_events-342a9dc3-0' immediately...\n"
+       "20:21:29.612 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'augment_tracking_events-342a9dc3-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -482,11 +482,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:35.088 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'augment_tracking_events-342a9dc3-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:30.648 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'augment_tracking_events-342a9dc3-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:35.088 | \u001b[36mINFO\u001b[0m    | Task run 'augment_tracking_events-342a9dc3-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:21:30.648 | \u001b[36mINFO\u001b[0m    | Task run 'augment_tracking_events-342a9dc3-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -495,11 +495,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:35.128 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Created task run 'transform_to_tracking_display-0c78dc49-0' for task 'transform_to_tracking_display'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:30.674 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'transform_to_tracking_display-0c78dc49-0' for task 'transform_to_tracking_display'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:35.128 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Created task run 'transform_to_tracking_display-0c78dc49-0' for task 'transform_to_tracking_display'\n"
+       "20:21:30.674 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'transform_to_tracking_display-0c78dc49-0' for task 'transform_to_tracking_display'\n"
       ]
      },
      "metadata": {},
@@ -508,11 +508,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:35.131 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Executing 'transform_to_tracking_display-0c78dc49-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:30.676 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'transform_to_tracking_display-0c78dc49-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:35.131 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Executing 'transform_to_tracking_display-0c78dc49-0' immediately...\n"
+       "20:21:30.676 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'transform_to_tracking_display-0c78dc49-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -521,11 +521,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:38.525 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'transform_to_tracking_display-0c78dc49-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:33.740 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'transform_to_tracking_display-0c78dc49-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:38.525 | \u001b[36mINFO\u001b[0m    | Task run 'transform_to_tracking_display-0c78dc49-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:21:33.740 | \u001b[36mINFO\u001b[0m    | Task run 'transform_to_tracking_display-0c78dc49-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -534,11 +534,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:38.556 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Created task run 'transform_to_frames-3446c324-0' for task 'transform_to_frames'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:33.765 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'transform_to_frames-3446c324-0' for task 'transform_to_frames'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:38.556 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Created task run 'transform_to_frames-3446c324-0' for task 'transform_to_frames'\n"
+       "20:21:33.765 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'transform_to_frames-3446c324-0' for task 'transform_to_frames'\n"
       ]
      },
      "metadata": {},
@@ -547,11 +547,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:38.558 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Executing 'transform_to_frames-3446c324-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:33.766 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'transform_to_frames-3446c324-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:38.558 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Executing 'transform_to_frames-3446c324-0' immediately...\n"
+       "20:21:33.766 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'transform_to_frames-3446c324-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -560,11 +560,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:45.809 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'transform_to_frames-3446c324-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:40.050 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'transform_to_frames-3446c324-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:45.809 | \u001b[36mINFO\u001b[0m    | Task run 'transform_to_frames-3446c324-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:21:40.050 | \u001b[36mINFO\u001b[0m    | Task run 'transform_to_frames-3446c324-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -573,11 +573,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:45.837 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Created task run 'transform_to_records_per_frame-823b8998-0' for task 'transform_to_records_per_frame'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:40.088 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'transform_to_records_per_frame-823b8998-0' for task 'transform_to_records_per_frame'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:45.837 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Created task run 'transform_to_records_per_frame-823b8998-0' for task 'transform_to_records_per_frame'\n"
+       "20:21:40.088 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'transform_to_records_per_frame-823b8998-0' for task 'transform_to_records_per_frame'\n"
       ]
      },
      "metadata": {},
@@ -586,11 +586,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:45.839 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Executing 'transform_to_records_per_frame-823b8998-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:40.090 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'transform_to_records_per_frame-823b8998-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:45.839 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Executing 'transform_to_records_per_frame-823b8998-0' immediately...\n"
+       "20:21:40.090 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'transform_to_records_per_frame-823b8998-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -599,11 +599,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:51.058 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'transform_to_records_per_frame-823b8998-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:45.124 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'transform_to_records_per_frame-823b8998-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:51.058 | \u001b[36mINFO\u001b[0m    | Task run 'transform_to_records_per_frame-823b8998-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:21:45.124 | \u001b[36mINFO\u001b[0m    | Task run 'transform_to_records_per_frame-823b8998-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -612,11 +612,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:51.113 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Created task run 'calculate_pocket_area-cc18ef62-1' for task 'calculate_pocket_area'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:45.191 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'calculate_pocket_area-cc18ef62-4' for task 'calculate_pocket_area'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:51.113 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-1' for task 'calculate_pocket_area'\n"
+       "20:21:45.191 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-4' for task 'calculate_pocket_area'\n"
       ]
      },
      "metadata": {},
@@ -625,11 +625,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:51.115 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-1' for execution.\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:45.194 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-4' for execution.\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:51.115 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-1' for execution.\n"
+       "20:21:45.194 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-4' for execution.\n"
       ]
      },
      "metadata": {},
@@ -638,11 +638,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:51.141 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Created task run 'calculate_pocket_area-cc18ef62-2' for task 'calculate_pocket_area'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:45.218 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'calculate_pocket_area-cc18ef62-3' for task 'calculate_pocket_area'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:51.141 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-2' for task 'calculate_pocket_area'\n"
+       "20:21:45.218 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-3' for task 'calculate_pocket_area'\n"
       ]
      },
      "metadata": {},
@@ -651,11 +651,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:51.143 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-2' for execution.\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:45.220 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-3' for execution.\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:51.143 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-2' for execution.\n"
+       "20:21:45.220 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-3' for execution.\n"
       ]
      },
      "metadata": {},
@@ -664,11 +664,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:51.175 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Created task run 'calculate_pocket_area-cc18ef62-0' for task 'calculate_pocket_area'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:45.252 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'calculate_pocket_area-cc18ef62-2' for task 'calculate_pocket_area'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:51.175 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-0' for task 'calculate_pocket_area'\n"
+       "20:21:45.252 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-2' for task 'calculate_pocket_area'\n"
       ]
      },
      "metadata": {},
@@ -677,11 +677,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:51.178 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-0' for execution.\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:45.255 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-2' for execution.\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:51.178 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-0' for execution.\n"
+       "20:21:45.255 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-2' for execution.\n"
       ]
      },
      "metadata": {},
@@ -690,11 +690,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:51.227 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Created task run 'calculate_pocket_area-cc18ef62-3' for task 'calculate_pocket_area'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:45.316 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'calculate_pocket_area-cc18ef62-1' for task 'calculate_pocket_area'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:51.227 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-3' for task 'calculate_pocket_area'\n"
+       "20:21:45.316 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-1' for task 'calculate_pocket_area'\n"
       ]
      },
      "metadata": {},
@@ -703,11 +703,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:51.231 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-3' for execution.\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:45.319 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-1' for execution.\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:51.231 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-3' for execution.\n"
+       "20:21:45.319 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-1' for execution.\n"
       ]
      },
      "metadata": {},
@@ -716,11 +716,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:51.411 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Created task run 'union_dataframes-8a4e3d8f-0' for task 'union_dataframes'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:45.410 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'calculate_pocket_area-cc18ef62-0' for task 'calculate_pocket_area'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:51.411 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Created task run 'union_dataframes-8a4e3d8f-0' for task 'union_dataframes'\n"
+       "20:21:45.410 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-0' for task 'calculate_pocket_area'\n"
       ]
      },
      "metadata": {},
@@ -729,11 +729,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:51.435 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Executing 'union_dataframes-8a4e3d8f-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:45.416 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-0' for execution.\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:51.435 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Executing 'union_dataframes-8a4e3d8f-0' immediately...\n"
+       "20:21:45.416 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-0' for execution.\n"
       ]
      },
      "metadata": {},
@@ -742,436 +742,63 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:10:59.506 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:45.542 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'union_dataframes-8a4e3d8f-0' for task 'union_dataframes'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:10:59.506 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:21:45.542 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'union_dataframes-8a4e3d8f-0' for task 'union_dataframes'\n"
       ]
      },
      "metadata": {},
      "output_type": "display_data"
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n",
-      "Exception in rushers_pocket_area(): QH6214 qhull input error: not enough points(2) to construct initial simplex (need 3)\n",
-      "\n",
-      "While executing:  | qhull i Qt\n",
-      "Options selected for Qhull 2019.1.r 2019/06/21:\n",
-      "  run-id 108178738  incidence  Qtriangulate  _pre-merge  _zero-centrum\n",
-      "  _maxoutside  0\n",
-      "\n"
-     ]
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:45.547 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'union_dataframes-8a4e3d8f-0' immediately...\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "20:21:45.547 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'union_dataframes-8a4e3d8f-0' immediately...\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:54.549 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "20:21:54.549 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:28.930 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-3' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "20:24:28.930 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-3' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:13:13.089 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-3' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:51.105 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-4' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:13:13.089 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-3' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:24:51.105 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-4' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -1180,11 +807,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:13:17.924 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:54.071 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-2' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:13:17.924 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:24:54.071 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-2' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -1193,11 +820,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:13:20.168 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-2' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:54.981 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:13:20.168 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-2' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:24:54.981 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -1206,11 +833,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:13:20.245 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'union_dataframes-8a4e3d8f-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:55.060 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'union_dataframes-8a4e3d8f-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:13:20.245 | \u001b[36mINFO\u001b[0m    | Task run 'union_dataframes-8a4e3d8f-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:24:55.060 | \u001b[36mINFO\u001b[0m    | Task run 'union_dataframes-8a4e3d8f-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -1219,11 +846,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:13:20.276 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Created task run 'get_frames_for_time_windows-182f3eb1-0' for task 'get_frames_for_time_windows'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:55.088 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'get_frames_for_time_windows-182f3eb1-0' for task 'get_frames_for_time_windows'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:13:20.276 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Created task run 'get_frames_for_time_windows-182f3eb1-0' for task 'get_frames_for_time_windows'\n"
+       "20:24:55.088 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'get_frames_for_time_windows-182f3eb1-0' for task 'get_frames_for_time_windows'\n"
       ]
      },
      "metadata": {},
@@ -1232,11 +859,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:13:20.278 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Executing 'get_frames_for_time_windows-182f3eb1-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:55.090 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'get_frames_for_time_windows-182f3eb1-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:13:20.278 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Executing 'get_frames_for_time_windows-182f3eb1-0' immediately...\n"
+       "20:24:55.090 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'get_frames_for_time_windows-182f3eb1-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -1245,11 +872,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:13:20.616 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'get_frames_for_time_windows-182f3eb1-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:55.487 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'get_frames_for_time_windows-182f3eb1-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:13:20.616 | \u001b[36mINFO\u001b[0m    | Task run 'get_frames_for_time_windows-182f3eb1-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:24:55.487 | \u001b[36mINFO\u001b[0m    | Task run 'get_frames_for_time_windows-182f3eb1-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -1258,11 +885,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:13:20.644 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Created task run 'get_play_pocket_metrics-c9059079-0' for task 'get_play_pocket_metrics'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:55.518 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'get_play_pocket_metrics-c9059079-0' for task 'get_play_pocket_metrics'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:13:20.644 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Created task run 'get_play_pocket_metrics-c9059079-0' for task 'get_play_pocket_metrics'\n"
+       "20:24:55.518 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'get_play_pocket_metrics-c9059079-0' for task 'get_play_pocket_metrics'\n"
       ]
      },
      "metadata": {},
@@ -1271,11 +898,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:13:20.647 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Executing 'get_play_pocket_metrics-c9059079-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:55.520 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'get_play_pocket_metrics-c9059079-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:13:20.647 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Executing 'get_play_pocket_metrics-c9059079-0' immediately...\n"
+       "20:24:55.520 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'get_play_pocket_metrics-c9059079-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -1284,11 +911,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:13:21.127 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'get_play_pocket_metrics-c9059079-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:56.086 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'get_play_pocket_metrics-c9059079-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:13:21.127 | \u001b[36mINFO\u001b[0m    | Task run 'get_play_pocket_metrics-c9059079-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:24:56.086 | \u001b[36mINFO\u001b[0m    | Task run 'get_play_pocket_metrics-c9059079-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -1297,11 +924,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:13:21.177 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Created task run 'calculate_average_pocket_area_loss_per_second-c688e278-0' for task 'calculate_average_pocket_area_loss_per_second'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:56.119 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'calculate_average_pocket_area_loss_per_second-c688e278-0' for task 'calculate_average_pocket_area_loss_per_second'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:13:21.177 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Created task run 'calculate_average_pocket_area_loss_per_second-c688e278-0' for task 'calculate_average_pocket_area_loss_per_second'\n"
+       "20:24:56.119 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'calculate_average_pocket_area_loss_per_second-c688e278-0' for task 'calculate_average_pocket_area_loss_per_second'\n"
       ]
      },
      "metadata": {},
@@ -1310,11 +937,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:13:21.179 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Executing 'calculate_average_pocket_area_loss_per_second-c688e278-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:56.122 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'calculate_average_pocket_area_loss_per_second-c688e278-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:13:21.179 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Executing 'calculate_average_pocket_area_loss_per_second-c688e278-0' immediately...\n"
+       "20:24:56.122 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'calculate_average_pocket_area_loss_per_second-c688e278-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -1323,11 +950,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:13:21.735 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_average_pocket_area_loss_per_second-c688e278-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:56.733 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_average_pocket_area_loss_per_second-c688e278-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:13:21.735 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_average_pocket_area_loss_per_second-c688e278-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:24:56.733 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_average_pocket_area_loss_per_second-c688e278-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -1336,11 +963,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:13:21.762 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Created task run 'write_csv-386fe2af-0' for task 'write_csv'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:56.762 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'write_csv-386fe2af-0' for task 'write_csv'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:13:21.762 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Created task run 'write_csv-386fe2af-0' for task 'write_csv'\n"
+       "20:24:56.762 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'write_csv-386fe2af-0' for task 'write_csv'\n"
       ]
      },
      "metadata": {},
@@ -1349,11 +976,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:13:21.764 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Executing 'write_csv-386fe2af-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:56.764 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'write_csv-386fe2af-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:13:21.764 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Executing 'write_csv-386fe2af-0' immediately...\n"
+       "20:24:56.764 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'write_csv-386fe2af-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -1362,11 +989,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:13:38.691 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:25:13.471 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:13:38.691 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:25:13.471 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -1375,11 +1002,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:13:38.720 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Created task run 'write_csv-386fe2af-1' for task 'write_csv'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:25:13.509 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'write_csv-386fe2af-1' for task 'write_csv'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:13:38.720 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Created task run 'write_csv-386fe2af-1' for task 'write_csv'\n"
+       "20:25:13.509 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'write_csv-386fe2af-1' for task 'write_csv'\n"
       ]
      },
      "metadata": {},
@@ -1388,11 +1015,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:13:38.722 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Executing 'write_csv-386fe2af-1' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:25:13.512 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'write_csv-386fe2af-1' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:13:38.722 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Executing 'write_csv-386fe2af-1' immediately...\n"
+       "20:25:13.512 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'write_csv-386fe2af-1' immediately...\n"
       ]
      },
      "metadata": {},
@@ -1401,11 +1028,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:13:39.020 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:25:13.824 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:13:39.020 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:25:13.824 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -1414,11 +1041,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:13:39.051 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Created task run 'write_csv-386fe2af-2' for task 'write_csv'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:25:13.853 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'write_csv-386fe2af-2' for task 'write_csv'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:13:39.051 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Created task run 'write_csv-386fe2af-2' for task 'write_csv'\n"
+       "20:25:13.853 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'write_csv-386fe2af-2' for task 'write_csv'\n"
       ]
      },
      "metadata": {},
@@ -1427,11 +1054,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:13:39.054 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Executing 'write_csv-386fe2af-2' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:25:13.856 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'write_csv-386fe2af-2' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:13:39.054 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Executing 'write_csv-386fe2af-2' immediately...\n"
+       "20:25:13.856 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'write_csv-386fe2af-2' immediately...\n"
       ]
      },
      "metadata": {},
@@ -1440,11 +1067,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:13:44.814 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-2' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:25:20.918 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-2' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:13:44.814 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-2' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:25:20.918 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-2' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -1453,11 +1080,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:13:44.841 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Created task run 'write_csv-386fe2af-3' for task 'write_csv'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:25:20.949 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'write_csv-386fe2af-3' for task 'write_csv'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:13:44.841 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Created task run 'write_csv-386fe2af-3' for task 'write_csv'\n"
+       "20:25:20.949 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'write_csv-386fe2af-3' for task 'write_csv'\n"
       ]
      },
      "metadata": {},
@@ -1466,11 +1093,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:13:44.844 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Executing 'write_csv-386fe2af-3' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:25:20.951 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'write_csv-386fe2af-3' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:13:44.844 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Executing 'write_csv-386fe2af-3' immediately...\n"
+       "20:25:20.951 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'write_csv-386fe2af-3' immediately...\n"
       ]
      },
      "metadata": {},
@@ -1479,11 +1106,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:13:45.446 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-3' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:25:21.645 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-3' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:13:45.446 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-3' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:25:21.645 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-3' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -1492,11 +1119,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">05:13:45.494 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'elegant-mule'</span> - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>('All states completed.')\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:25:21.691 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>('All states completed.')\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "05:13:45.494 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'elegant-mule'\u001b[0m - Finished in state \u001b[32mCompleted\u001b[0m('All states completed.')\n"
+       "20:25:21.691 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Finished in state \u001b[32mCompleted\u001b[0m('All states completed.')\n"
       ]
      },
      "metadata": {},
@@ -1518,86 +1145,89 @@
    "source": [
     "# Copy the raw Prefect log from above and paste it into this multi-line variable.\n",
     "raw_log = \"\"\"\n",
-    "05:10:19.253 | INFO    | prefect.engine - Created flow run 'elegant-mule' for flow 'main-flow'\n",
-    "05:10:19.418 | INFO    | Flow run 'elegant-mule' - Created task run 'read_csv-3609c996-0' for task 'read_csv'\n",
-    "05:10:19.421 | INFO    | Flow run 'elegant-mule' - Executing 'read_csv-3609c996-0' immediately...\n",
-    "05:10:19.838 | INFO    | Task run 'read_csv-3609c996-0' - Finished in state Completed()\n",
-    "05:10:19.865 | INFO    | Flow run 'elegant-mule' - Created task run 'read_csv-3609c996-1' for task 'read_csv'\n",
-    "05:10:19.867 | INFO    | Flow run 'elegant-mule' - Executing 'read_csv-3609c996-1' immediately...\n",
-    "05:10:19.966 | INFO    | Task run 'read_csv-3609c996-1' - Finished in state Completed()\n",
-    "05:10:19.994 | INFO    | Flow run 'elegant-mule' - Created task run 'read_tracking_data-e2eae939-0' for task 'read_tracking_data'\n",
-    "05:10:19.996 | INFO    | Flow run 'elegant-mule' - Executing 'read_tracking_data-e2eae939-0' immediately...\n",
-    "05:10:24.819 | INFO    | Task run 'read_tracking_data-e2eae939-0' - Finished in state Completed()\n",
-    "05:10:24.851 | INFO    | Flow run 'elegant-mule' - Created task run 'limit_by_child_keys-4238f776-0' for task 'limit_by_child_keys'\n",
-    "05:10:24.853 | INFO    | Flow run 'elegant-mule' - Executing 'limit_by_child_keys-4238f776-0' immediately...\n",
-    "05:10:24.921 | INFO    | Task run 'limit_by_child_keys-4238f776-0' - Finished in state Completed()\n",
-    "05:10:24.950 | INFO    | Flow run 'elegant-mule' - Created task run 'limit_by_child_keys-4238f776-1' for task 'limit_by_child_keys'\n",
-    "05:10:24.953 | INFO    | Flow run 'elegant-mule' - Executing 'limit_by_child_keys-4238f776-1' immediately...\n",
-    "05:10:25.018 | INFO    | Task run 'limit_by_child_keys-4238f776-1' - Finished in state Completed()\n",
-    "05:10:25.045 | INFO    | Flow run 'elegant-mule' - Created task run 'align_tracking_data-ea7afe30-0' for task 'align_tracking_data'\n",
-    "05:10:25.047 | INFO    | Flow run 'elegant-mule' - Executing 'align_tracking_data-ea7afe30-0' immediately...\n",
-    "05:10:26.899 | INFO    | Task run 'align_tracking_data-ea7afe30-0' - Finished in state Completed()\n",
-    "05:10:26.931 | INFO    | Flow run 'elegant-mule' - Created task run 'rotate_tracking_data-13ea6cce-0' for task 'rotate_tracking_data'\n",
-    "05:10:26.933 | INFO    | Flow run 'elegant-mule' - Executing 'rotate_tracking_data-13ea6cce-0' immediately...\n",
-    "05:10:27.069 | INFO    | Task run 'rotate_tracking_data-13ea6cce-0' - Finished in state Completed()\n",
-    "05:10:27.105 | INFO    | Flow run 'elegant-mule' - Created task run 'get_passer_out_of_pocket-98072e46-0' for task 'get_passer_out_of_pocket'\n",
-    "05:10:27.107 | INFO    | Flow run 'elegant-mule' - Executing 'get_passer_out_of_pocket-98072e46-0' immediately...\n",
-    "05:10:32.118 | INFO    | Task run 'get_passer_out_of_pocket-98072e46-0' - Finished in state Completed()\n",
-    "05:10:32.152 | INFO    | Flow run 'elegant-mule' - Created task run 'clean_event_data-657c8302-0' for task 'clean_event_data'\n",
-    "05:10:32.154 | INFO    | Flow run 'elegant-mule' - Executing 'clean_event_data-657c8302-0' immediately...\n",
-    "05:10:33.902 | INFO    | Task run 'clean_event_data-657c8302-0' - Finished in state Completed()\n",
-    "05:10:33.935 | INFO    | Flow run 'elegant-mule' - Created task run 'get_pocket_eligibility-6d653879-0' for task 'get_pocket_eligibility'\n",
-    "05:10:33.939 | INFO    | Flow run 'elegant-mule' - Executing 'get_pocket_eligibility-6d653879-0' immediately...\n",
-    "05:10:34.130 | INFO    | Task run 'get_pocket_eligibility-6d653879-0' - Finished in state Completed()\n",
-    "05:10:34.161 | INFO    | Flow run 'elegant-mule' - Created task run 'augment_tracking_events-342a9dc3-0' for task 'augment_tracking_events'\n",
-    "05:10:34.163 | INFO    | Flow run 'elegant-mule' - Executing 'augment_tracking_events-342a9dc3-0' immediately...\n",
-    "05:10:35.088 | INFO    | Task run 'augment_tracking_events-342a9dc3-0' - Finished in state Completed()\n",
-    "05:10:35.128 | INFO    | Flow run 'elegant-mule' - Created task run 'transform_to_tracking_display-0c78dc49-0' for task 'transform_to_tracking_display'\n",
-    "05:10:35.131 | INFO    | Flow run 'elegant-mule' - Executing 'transform_to_tracking_display-0c78dc49-0' immediately...\n",
-    "05:10:38.525 | INFO    | Task run 'transform_to_tracking_display-0c78dc49-0' - Finished in state Completed()\n",
-    "05:10:38.556 | INFO    | Flow run 'elegant-mule' - Created task run 'transform_to_frames-3446c324-0' for task 'transform_to_frames'\n",
-    "05:10:38.558 | INFO    | Flow run 'elegant-mule' - Executing 'transform_to_frames-3446c324-0' immediately...\n",
-    "05:10:45.809 | INFO    | Task run 'transform_to_frames-3446c324-0' - Finished in state Completed()\n",
-    "05:10:45.837 | INFO    | Flow run 'elegant-mule' - Created task run 'transform_to_records_per_frame-823b8998-0' for task 'transform_to_records_per_frame'\n",
-    "05:10:45.839 | INFO    | Flow run 'elegant-mule' - Executing 'transform_to_records_per_frame-823b8998-0' immediately...\n",
-    "05:10:51.058 | INFO    | Task run 'transform_to_records_per_frame-823b8998-0' - Finished in state Completed()\n",
-    "05:10:51.113 | INFO    | Flow run 'elegant-mule' - Created task run 'calculate_pocket_area-cc18ef62-1' for task 'calculate_pocket_area'\n",
-    "05:10:51.115 | INFO    | Flow run 'elegant-mule' - Submitted task run 'calculate_pocket_area-cc18ef62-1' for execution.\n",
-    "05:10:51.141 | INFO    | Flow run 'elegant-mule' - Created task run 'calculate_pocket_area-cc18ef62-2' for task 'calculate_pocket_area'\n",
-    "05:10:51.143 | INFO    | Flow run 'elegant-mule' - Submitted task run 'calculate_pocket_area-cc18ef62-2' for execution.\n",
-    "05:10:51.175 | INFO    | Flow run 'elegant-mule' - Created task run 'calculate_pocket_area-cc18ef62-0' for task 'calculate_pocket_area'\n",
-    "05:10:51.178 | INFO    | Flow run 'elegant-mule' - Submitted task run 'calculate_pocket_area-cc18ef62-0' for execution.\n",
-    "05:10:51.227 | INFO    | Flow run 'elegant-mule' - Created task run 'calculate_pocket_area-cc18ef62-3' for task 'calculate_pocket_area'\n",
-    "05:10:51.231 | INFO    | Flow run 'elegant-mule' - Submitted task run 'calculate_pocket_area-cc18ef62-3' for execution.\n",
-    "05:10:51.411 | INFO    | Flow run 'elegant-mule' - Created task run 'union_dataframes-8a4e3d8f-0' for task 'union_dataframes'\n",
-    "05:10:51.435 | INFO    | Flow run 'elegant-mule' - Executing 'union_dataframes-8a4e3d8f-0' immediately...\n",
-    "05:10:59.506 | INFO    | Task run 'calculate_pocket_area-cc18ef62-0' - Finished in state Completed()\n",
-    "05:13:13.089 | INFO    | Task run 'calculate_pocket_area-cc18ef62-3' - Finished in state Completed()\n",
-    "05:13:17.924 | INFO    | Task run 'calculate_pocket_area-cc18ef62-1' - Finished in state Completed()\n",
-    "05:13:20.168 | INFO    | Task run 'calculate_pocket_area-cc18ef62-2' - Finished in state Completed()\n",
-    "05:13:20.245 | INFO    | Task run 'union_dataframes-8a4e3d8f-0' - Finished in state Completed()\n",
-    "05:13:20.276 | INFO    | Flow run 'elegant-mule' - Created task run 'get_frames_for_time_windows-182f3eb1-0' for task 'get_frames_for_time_windows'\n",
-    "05:13:20.278 | INFO    | Flow run 'elegant-mule' - Executing 'get_frames_for_time_windows-182f3eb1-0' immediately...\n",
-    "05:13:20.616 | INFO    | Task run 'get_frames_for_time_windows-182f3eb1-0' - Finished in state Completed()\n",
-    "05:13:20.644 | INFO    | Flow run 'elegant-mule' - Created task run 'get_play_pocket_metrics-c9059079-0' for task 'get_play_pocket_metrics'\n",
-    "05:13:20.647 | INFO    | Flow run 'elegant-mule' - Executing 'get_play_pocket_metrics-c9059079-0' immediately...\n",
-    "05:13:21.127 | INFO    | Task run 'get_play_pocket_metrics-c9059079-0' - Finished in state Completed()\n",
-    "05:13:21.177 | INFO    | Flow run 'elegant-mule' - Created task run 'calculate_average_pocket_area_loss_per_second-c688e278-0' for task 'calculate_average_pocket_area_loss_per_second'\n",
-    "05:13:21.179 | INFO    | Flow run 'elegant-mule' - Executing 'calculate_average_pocket_area_loss_per_second-c688e278-0' immediately...\n",
-    "05:13:21.735 | INFO    | Task run 'calculate_average_pocket_area_loss_per_second-c688e278-0' - Finished in state Completed()\n",
-    "05:13:21.762 | INFO    | Flow run 'elegant-mule' - Created task run 'write_csv-386fe2af-0' for task 'write_csv'\n",
-    "05:13:21.764 | INFO    | Flow run 'elegant-mule' - Executing 'write_csv-386fe2af-0' immediately...\n",
-    "05:13:38.691 | INFO    | Task run 'write_csv-386fe2af-0' - Finished in state Completed()\n",
-    "05:13:38.720 | INFO    | Flow run 'elegant-mule' - Created task run 'write_csv-386fe2af-1' for task 'write_csv'\n",
-    "05:13:38.722 | INFO    | Flow run 'elegant-mule' - Executing 'write_csv-386fe2af-1' immediately...\n",
-    "05:13:39.020 | INFO    | Task run 'write_csv-386fe2af-1' - Finished in state Completed()\n",
-    "05:13:39.051 | INFO    | Flow run 'elegant-mule' - Created task run 'write_csv-386fe2af-2' for task 'write_csv'\n",
-    "05:13:39.054 | INFO    | Flow run 'elegant-mule' - Executing 'write_csv-386fe2af-2' immediately...\n",
-    "05:13:44.814 | INFO    | Task run 'write_csv-386fe2af-2' - Finished in state Completed()\n",
-    "05:13:44.841 | INFO    | Flow run 'elegant-mule' - Created task run 'write_csv-386fe2af-3' for task 'write_csv'\n",
-    "05:13:44.844 | INFO    | Flow run 'elegant-mule' - Executing 'write_csv-386fe2af-3' immediately...\n",
-    "05:13:45.446 | INFO    | Task run 'write_csv-386fe2af-3' - Finished in state Completed()\n",
-    "05:13:45.494 | INFO    | Flow run 'elegant-mule' - Finished in state Completed('All states completed.')\n",
+    "20:21:17.803 | INFO    | prefect.engine - Created flow run 'little-seagull' for flow 'main-flow'\n",
+    "20:21:17.991 | INFO    | Flow run 'little-seagull' - Created task run 'read_csv-3609c996-0' for task 'read_csv'\n",
+    "20:21:17.995 | INFO    | Flow run 'little-seagull' - Executing 'read_csv-3609c996-0' immediately...\n",
+    "20:21:18.257 | INFO    | Task run 'read_csv-3609c996-0' - Finished in state Completed()\n",
+    "20:21:18.286 | INFO    | Flow run 'little-seagull' - Created task run 'read_csv-3609c996-1' for task 'read_csv'\n",
+    "20:21:18.289 | INFO    | Flow run 'little-seagull' - Executing 'read_csv-3609c996-1' immediately...\n",
+    "20:21:18.395 | INFO    | Task run 'read_csv-3609c996-1' - Finished in state Completed()\n",
+    "20:21:18.429 | INFO    | Flow run 'little-seagull' - Created task run 'read_tracking_data-e2eae939-0' for task 'read_tracking_data'\n",
+    "20:21:18.432 | INFO    | Flow run 'little-seagull' - Executing 'read_tracking_data-e2eae939-0' immediately...\n",
+    "20:21:22.129 | INFO    | Task run 'read_tracking_data-e2eae939-0' - Finished in state Completed()\n",
+    "20:21:22.154 | INFO    | Flow run 'little-seagull' - Created task run 'limit_by_child_keys-4238f776-0' for task 'limit_by_child_keys'\n",
+    "20:21:22.156 | INFO    | Flow run 'little-seagull' - Executing 'limit_by_child_keys-4238f776-0' immediately...\n",
+    "20:21:22.219 | INFO    | Task run 'limit_by_child_keys-4238f776-0' - Finished in state Completed()\n",
+    "20:21:22.247 | INFO    | Flow run 'little-seagull' - Created task run 'limit_by_child_keys-4238f776-1' for task 'limit_by_child_keys'\n",
+    "20:21:22.249 | INFO    | Flow run 'little-seagull' - Executing 'limit_by_child_keys-4238f776-1' immediately...\n",
+    "20:21:22.318 | INFO    | Task run 'limit_by_child_keys-4238f776-1' - Finished in state Completed()\n",
+    "20:21:22.348 | INFO    | Flow run 'little-seagull' - Created task run 'align_tracking_data-ea7afe30-0' for task 'align_tracking_data'\n",
+    "20:21:22.350 | INFO    | Flow run 'little-seagull' - Executing 'align_tracking_data-ea7afe30-0' immediately...\n",
+    "20:21:22.689 | INFO    | Task run 'align_tracking_data-ea7afe30-0' - Finished in state Completed()\n",
+    "20:21:22.718 | INFO    | Flow run 'little-seagull' - Created task run 'rotate_tracking_data-13ea6cce-0' for task 'rotate_tracking_data'\n",
+    "20:21:22.719 | INFO    | Flow run 'little-seagull' - Executing 'rotate_tracking_data-13ea6cce-0' immediately...\n",
+    "20:21:22.843 | INFO    | Task run 'rotate_tracking_data-13ea6cce-0' - Finished in state Completed()\n",
+    "20:21:22.878 | INFO    | Flow run 'little-seagull' - Created task run 'get_passer_out_of_pocket-98072e46-0' for task 'get_passer_out_of_pocket'\n",
+    "20:21:22.881 | INFO    | Flow run 'little-seagull' - Executing 'get_passer_out_of_pocket-98072e46-0' immediately...\n",
+    "20:21:27.741 | INFO    | Task run 'get_passer_out_of_pocket-98072e46-0' - Finished in state Completed()\n",
+    "20:21:27.766 | INFO    | Flow run 'little-seagull' - Created task run 'clean_event_data-657c8302-0' for task 'clean_event_data'\n",
+    "20:21:27.769 | INFO    | Flow run 'little-seagull' - Executing 'clean_event_data-657c8302-0' immediately...\n",
+    "20:21:29.379 | INFO    | Task run 'clean_event_data-657c8302-0' - Finished in state Completed()\n",
+    "20:21:29.406 | INFO    | Flow run 'little-seagull' - Created task run 'get_pocket_eligibility-6d653879-0' for task 'get_pocket_eligibility'\n",
+    "20:21:29.408 | INFO    | Flow run 'little-seagull' - Executing 'get_pocket_eligibility-6d653879-0' immediately...\n",
+    "20:21:29.583 | INFO    | Task run 'get_pocket_eligibility-6d653879-0' - Finished in state Completed()\n",
+    "20:21:29.610 | INFO    | Flow run 'little-seagull' - Created task run 'augment_tracking_events-342a9dc3-0' for task 'augment_tracking_events'\n",
+    "20:21:29.612 | INFO    | Flow run 'little-seagull' - Executing 'augment_tracking_events-342a9dc3-0' immediately...\n",
+    "20:21:30.648 | INFO    | Task run 'augment_tracking_events-342a9dc3-0' - Finished in state Completed()\n",
+    "20:21:30.674 | INFO    | Flow run 'little-seagull' - Created task run 'transform_to_tracking_display-0c78dc49-0' for task 'transform_to_tracking_display'\n",
+    "20:21:30.676 | INFO    | Flow run 'little-seagull' - Executing 'transform_to_tracking_display-0c78dc49-0' immediately...\n",
+    "20:21:33.740 | INFO    | Task run 'transform_to_tracking_display-0c78dc49-0' - Finished in state Completed()\n",
+    "20:21:33.765 | INFO    | Flow run 'little-seagull' - Created task run 'transform_to_frames-3446c324-0' for task 'transform_to_frames'\n",
+    "20:21:33.766 | INFO    | Flow run 'little-seagull' - Executing 'transform_to_frames-3446c324-0' immediately...\n",
+    "20:21:40.050 | INFO    | Task run 'transform_to_frames-3446c324-0' - Finished in state Completed()\n",
+    "20:21:40.088 | INFO    | Flow run 'little-seagull' - Created task run 'transform_to_records_per_frame-823b8998-0' for task 'transform_to_records_per_frame'\n",
+    "20:21:40.090 | INFO    | Flow run 'little-seagull' - Executing 'transform_to_records_per_frame-823b8998-0' immediately...\n",
+    "20:21:45.124 | INFO    | Task run 'transform_to_records_per_frame-823b8998-0' - Finished in state Completed()\n",
+    "20:21:45.191 | INFO    | Flow run 'little-seagull' - Created task run 'calculate_pocket_area-cc18ef62-4' for task 'calculate_pocket_area'\n",
+    "20:21:45.194 | INFO    | Flow run 'little-seagull' - Submitted task run 'calculate_pocket_area-cc18ef62-4' for execution.\n",
+    "20:21:45.218 | INFO    | Flow run 'little-seagull' - Created task run 'calculate_pocket_area-cc18ef62-3' for task 'calculate_pocket_area'\n",
+    "20:21:45.220 | INFO    | Flow run 'little-seagull' - Submitted task run 'calculate_pocket_area-cc18ef62-3' for execution.\n",
+    "20:21:45.252 | INFO    | Flow run 'little-seagull' - Created task run 'calculate_pocket_area-cc18ef62-2' for task 'calculate_pocket_area'\n",
+    "20:21:45.255 | INFO    | Flow run 'little-seagull' - Submitted task run 'calculate_pocket_area-cc18ef62-2' for execution.\n",
+    "20:21:45.316 | INFO    | Flow run 'little-seagull' - Created task run 'calculate_pocket_area-cc18ef62-1' for task 'calculate_pocket_area'\n",
+    "20:21:45.319 | INFO    | Flow run 'little-seagull' - Submitted task run 'calculate_pocket_area-cc18ef62-1' for execution.\n",
+    "20:21:45.410 | INFO    | Flow run 'little-seagull' - Created task run 'calculate_pocket_area-cc18ef62-0' for task 'calculate_pocket_area'\n",
+    "20:21:45.416 | INFO    | Flow run 'little-seagull' - Submitted task run 'calculate_pocket_area-cc18ef62-0' for execution.\n",
+    "20:21:45.542 | INFO    | Flow run 'little-seagull' - Created task run 'union_dataframes-8a4e3d8f-0' for task 'union_dataframes'\n",
+    "20:21:45.547 | INFO    | Flow run 'little-seagull' - Executing 'union_dataframes-8a4e3d8f-0' immediately...\n",
+    "20:21:54.549 | INFO    | Task run 'calculate_pocket_area-cc18ef62-0' - Finished in state Completed()\n",
+    "20:24:28.930 | INFO    | Task run 'calculate_pocket_area-cc18ef62-3' - Finished in state Completed()\n",
+    "20:24:51.105 | INFO    | Task run 'calculate_pocket_area-cc18ef62-4' - Finished in state Completed()\n",
+    "20:24:54.071 | INFO    | Task run 'calculate_pocket_area-cc18ef62-2' - Finished in state Completed()\n",
+    "20:24:54.981 | INFO    | Task run 'calculate_pocket_area-cc18ef62-1' - Finished in state Completed()\n",
+    "20:24:55.060 | INFO    | Task run 'union_dataframes-8a4e3d8f-0' - Finished in state Completed()\n",
+    "20:24:55.088 | INFO    | Flow run 'little-seagull' - Created task run 'get_frames_for_time_windows-182f3eb1-0' for task 'get_frames_for_time_windows'\n",
+    "20:24:55.090 | INFO    | Flow run 'little-seagull' - Executing 'get_frames_for_time_windows-182f3eb1-0' immediately...\n",
+    "20:24:55.487 | INFO    | Task run 'get_frames_for_time_windows-182f3eb1-0' - Finished in state Completed()\n",
+    "20:24:55.518 | INFO    | Flow run 'little-seagull' - Created task run 'get_play_pocket_metrics-c9059079-0' for task 'get_play_pocket_metrics'\n",
+    "20:24:55.520 | INFO    | Flow run 'little-seagull' - Executing 'get_play_pocket_metrics-c9059079-0' immediately...\n",
+    "20:24:56.086 | INFO    | Task run 'get_play_pocket_metrics-c9059079-0' - Finished in state Completed()\n",
+    "20:24:56.119 | INFO    | Flow run 'little-seagull' - Created task run 'calculate_average_pocket_area_loss_per_second-c688e278-0' for task 'calculate_average_pocket_area_loss_per_second'\n",
+    "20:24:56.122 | INFO    | Flow run 'little-seagull' - Executing 'calculate_average_pocket_area_loss_per_second-c688e278-0' immediately...\n",
+    "20:24:56.733 | INFO    | Task run 'calculate_average_pocket_area_loss_per_second-c688e278-0' - Finished in state Completed()\n",
+    "20:24:56.762 | INFO    | Flow run 'little-seagull' - Created task run 'write_csv-386fe2af-0' for task 'write_csv'\n",
+    "20:24:56.764 | INFO    | Flow run 'little-seagull' - Executing 'write_csv-386fe2af-0' immediately...\n",
+    "20:25:13.471 | INFO    | Task run 'write_csv-386fe2af-0' - Finished in state Completed()\n",
+    "20:25:13.509 | INFO    | Flow run 'little-seagull' - Created task run 'write_csv-386fe2af-1' for task 'write_csv'\n",
+    "20:25:13.512 | INFO    | Flow run 'little-seagull' - Executing 'write_csv-386fe2af-1' immediately...\n",
+    "20:25:13.824 | INFO    | Task run 'write_csv-386fe2af-1' - Finished in state Completed()\n",
+    "20:25:13.853 | INFO    | Flow run 'little-seagull' - Created task run 'write_csv-386fe2af-2' for task 'write_csv'\n",
+    "20:25:13.856 | INFO    | Flow run 'little-seagull' - Executing 'write_csv-386fe2af-2' immediately...\n",
+    "20:25:20.918 | INFO    | Task run 'write_csv-386fe2af-2' - Finished in state Completed()\n",
+    "20:25:20.949 | INFO    | Flow run 'little-seagull' - Created task run 'write_csv-386fe2af-3' for task 'write_csv'\n",
+    "20:25:20.951 | INFO    | Flow run 'little-seagull' - Executing 'write_csv-386fe2af-3' immediately...\n",
+    "20:25:21.645 | INFO    | Task run 'write_csv-386fe2af-3' - Finished in state Completed()\n",
+    "20:25:21.691 | INFO    | Flow run 'little-seagull' - Finished in state Completed('All states completed.')\n",
     "\"\"\""
    ]
   },
@@ -1634,122 +1264,127 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>calculate_pocket_area-cc18ef62-2</td>\n",
-       "      <td>149.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>21</th>\n",
-       "      <td>union_dataframes-8a4e3d8f-0</td>\n",
-       "      <td>148.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>calculate_pocket_area-cc18ef62-1</td>\n",
-       "      <td>146.0</td>\n",
+       "      <td>189.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>22</th>\n",
+       "      <td>union_dataframes-8a4e3d8f-0</td>\n",
+       "      <td>189.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>calculate_pocket_area-cc18ef62-2</td>\n",
+       "      <td>188.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>calculate_pocket_area-cc18ef62-4</td>\n",
+       "      <td>185.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
        "      <td>calculate_pocket_area-cc18ef62-3</td>\n",
-       "      <td>141.0</td>\n",
+       "      <td>163.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>22</th>\n",
+       "      <th>23</th>\n",
        "      <td>write_csv-386fe2af-0</td>\n",
        "      <td>16.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>calculate_pocket_area-cc18ef62-0</td>\n",
-       "      <td>8.0</td>\n",
+       "      <td>9.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>18</th>\n",
-       "      <td>transform_to_frames-3446c324-0</td>\n",
+       "      <th>25</th>\n",
+       "      <td>write_csv-386fe2af-2</td>\n",
        "      <td>7.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>24</th>\n",
-       "      <td>write_csv-386fe2af-2</td>\n",
-       "      <td>5.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>get_passer_out_of_pocket-98072e46-0</td>\n",
-       "      <td>5.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
        "      <th>19</th>\n",
+       "      <td>transform_to_frames-3446c324-0</td>\n",
+       "      <td>6.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20</th>\n",
        "      <td>transform_to_records_per_frame-823b8998-0</td>\n",
        "      <td>5.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>16</th>\n",
-       "      <td>read_tracking_data-e2eae939-0</td>\n",
+       "      <th>10</th>\n",
+       "      <td>get_passer_out_of_pocket-98072e46-0</td>\n",
        "      <td>4.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>20</th>\n",
+       "      <th>17</th>\n",
+       "      <td>read_tracking_data-e2eae939-0</td>\n",
+       "      <td>3.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21</th>\n",
        "      <td>transform_to_tracking_display-0c78dc49-0</td>\n",
        "      <td>3.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>align_tracking_data-ea7afe30-0</td>\n",
-       "      <td>1.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
+       "      <th>8</th>\n",
        "      <td>clean_event_data-657c8302-0</td>\n",
        "      <td>1.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>23</th>\n",
-       "      <td>write_csv-386fe2af-1</td>\n",
+       "      <th>1</th>\n",
+       "      <td>augment_tracking_events-342a9dc3-0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>align_tracking_data-ea7afe30-0</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>17</th>\n",
+       "      <th>18</th>\n",
        "      <td>rotate_tracking_data-13ea6cce-0</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
+       "      <th>24</th>\n",
+       "      <td>write_csv-386fe2af-1</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
        "      <th>13</th>\n",
-       "      <td>limit_by_child_keys-4238f776-1</td>\n",
-       "      <td>0.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>15</th>\n",
-       "      <td>read_csv-3609c996-1</td>\n",
-       "      <td>0.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>14</th>\n",
-       "      <td>read_csv-3609c996-0</td>\n",
-       "      <td>0.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>augment_tracking_events-342a9dc3-0</td>\n",
-       "      <td>0.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>12</th>\n",
        "      <td>limit_by_child_keys-4238f776-0</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>11</th>\n",
+       "      <th>16</th>\n",
+       "      <td>read_csv-3609c996-1</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>read_csv-3609c996-0</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>limit_by_child_keys-4238f776-1</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
        "      <td>get_pocket_eligibility-6d653879-0</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>10</th>\n",
+       "      <th>11</th>\n",
        "      <td>get_play_pocket_metrics-c9059079-0</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>8</th>\n",
+       "      <th>9</th>\n",
        "      <td>get_frames_for_time_windows-182f3eb1-0</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
@@ -1759,7 +1394,7 @@
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>25</th>\n",
+       "      <th>26</th>\n",
        "      <td>write_csv-386fe2af-3</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
@@ -1769,32 +1404,33 @@
       ],
       "text/plain": [
        "                                                 task  elapsed_secs\n",
-       "5                    calculate_pocket_area-cc18ef62-2         149.0\n",
-       "21                        union_dataframes-8a4e3d8f-0         148.0\n",
-       "4                    calculate_pocket_area-cc18ef62-1         146.0\n",
-       "6                    calculate_pocket_area-cc18ef62-3         141.0\n",
-       "22                               write_csv-386fe2af-0          16.0\n",
-       "3                    calculate_pocket_area-cc18ef62-0           8.0\n",
-       "18                     transform_to_frames-3446c324-0           7.0\n",
-       "24                               write_csv-386fe2af-2           5.0\n",
-       "9                 get_passer_out_of_pocket-98072e46-0           5.0\n",
-       "19          transform_to_records_per_frame-823b8998-0           5.0\n",
-       "16                      read_tracking_data-e2eae939-0           4.0\n",
-       "20           transform_to_tracking_display-0c78dc49-0           3.0\n",
-       "0                      align_tracking_data-ea7afe30-0           1.0\n",
-       "7                         clean_event_data-657c8302-0           1.0\n",
-       "23                               write_csv-386fe2af-1           0.0\n",
-       "17                    rotate_tracking_data-13ea6cce-0           0.0\n",
-       "13                     limit_by_child_keys-4238f776-1           0.0\n",
-       "15                                read_csv-3609c996-1           0.0\n",
-       "14                                read_csv-3609c996-0           0.0\n",
-       "1                  augment_tracking_events-342a9dc3-0           0.0\n",
-       "12                     limit_by_child_keys-4238f776-0           0.0\n",
-       "11                  get_pocket_eligibility-6d653879-0           0.0\n",
-       "10                 get_play_pocket_metrics-c9059079-0           0.0\n",
-       "8              get_frames_for_time_windows-182f3eb1-0           0.0\n",
+       "4                    calculate_pocket_area-cc18ef62-1         189.0\n",
+       "22                        union_dataframes-8a4e3d8f-0         189.0\n",
+       "5                    calculate_pocket_area-cc18ef62-2         188.0\n",
+       "7                    calculate_pocket_area-cc18ef62-4         185.0\n",
+       "6                    calculate_pocket_area-cc18ef62-3         163.0\n",
+       "23                               write_csv-386fe2af-0          16.0\n",
+       "3                    calculate_pocket_area-cc18ef62-0           9.0\n",
+       "25                               write_csv-386fe2af-2           7.0\n",
+       "19                     transform_to_frames-3446c324-0           6.0\n",
+       "20          transform_to_records_per_frame-823b8998-0           5.0\n",
+       "10                get_passer_out_of_pocket-98072e46-0           4.0\n",
+       "17                      read_tracking_data-e2eae939-0           3.0\n",
+       "21           transform_to_tracking_display-0c78dc49-0           3.0\n",
+       "8                         clean_event_data-657c8302-0           1.0\n",
+       "1                  augment_tracking_events-342a9dc3-0           1.0\n",
+       "0                      align_tracking_data-ea7afe30-0           0.0\n",
+       "18                    rotate_tracking_data-13ea6cce-0           0.0\n",
+       "24                               write_csv-386fe2af-1           0.0\n",
+       "13                     limit_by_child_keys-4238f776-0           0.0\n",
+       "16                                read_csv-3609c996-1           0.0\n",
+       "15                                read_csv-3609c996-0           0.0\n",
+       "14                     limit_by_child_keys-4238f776-1           0.0\n",
+       "12                  get_pocket_eligibility-6d653879-0           0.0\n",
+       "11                 get_play_pocket_metrics-c9059079-0           0.0\n",
+       "9              get_frames_for_time_windows-182f3eb1-0           0.0\n",
        "2   calculate_average_pocket_area_loss_per_second-...           0.0\n",
-       "25                               write_csv-386fe2af-3           0.0"
+       "26                               write_csv-386fe2af-3           0.0"
       ]
      },
      "execution_count": 7,
@@ -1828,8 +1464,57 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "79fb17b1",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "FileNotFoundError",
+     "evalue": "[Errno 2] No such file or directory: '/workspace/nflbigdatabowl2023/data/outputs/pocket_areas.csv'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[11], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m df_plays_all \u001b[38;5;241m=\u001b[39m pd\u001b[38;5;241m.\u001b[39mread_csv(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mDIR\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m/data/raw/plays.csv\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m      2\u001b[0m \u001b[38;5;66;03m# df_tracking_display_all = pd.read_csv(f\"{DIR}/data/outputs/tracking_display.csv\")\u001b[39;00m\n\u001b[0;32m----> 3\u001b[0m df_areas_all \u001b[38;5;241m=\u001b[39m \u001b[43mpd\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mread_csv\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43mf\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;132;43;01m{\u001b[39;49;00m\u001b[43mDIR\u001b[49m\u001b[38;5;132;43;01m}\u001b[39;49;00m\u001b[38;5;124;43m/data/outputs/pocket_areas.csv\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m      4\u001b[0m df_areas_all[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mpocket\u001b[39m\u001b[38;5;124m\"\u001b[39m] \u001b[38;5;241m=\u001b[39m df_areas_all[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mpocket\u001b[39m\u001b[38;5;124m\"\u001b[39m]\u001b[38;5;241m.\u001b[39mapply(literal_eval)\n",
+      "File \u001b[0;32m/workspace/nflbigdatabowl2023/.venv/lib/python3.8/site-packages/pandas/util/_decorators.py:211\u001b[0m, in \u001b[0;36mdeprecate_kwarg.<locals>._deprecate_kwarg.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    209\u001b[0m     \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m    210\u001b[0m         kwargs[new_arg_name] \u001b[38;5;241m=\u001b[39m new_arg_value\n\u001b[0;32m--> 211\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m/workspace/nflbigdatabowl2023/.venv/lib/python3.8/site-packages/pandas/util/_decorators.py:331\u001b[0m, in \u001b[0;36mdeprecate_nonkeyword_arguments.<locals>.decorate.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    325\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mlen\u001b[39m(args) \u001b[38;5;241m>\u001b[39m num_allow_args:\n\u001b[1;32m    326\u001b[0m     warnings\u001b[38;5;241m.\u001b[39mwarn(\n\u001b[1;32m    327\u001b[0m         msg\u001b[38;5;241m.\u001b[39mformat(arguments\u001b[38;5;241m=\u001b[39m_format_argument_list(allow_args)),\n\u001b[1;32m    328\u001b[0m         \u001b[38;5;167;01mFutureWarning\u001b[39;00m,\n\u001b[1;32m    329\u001b[0m         stacklevel\u001b[38;5;241m=\u001b[39mfind_stack_level(),\n\u001b[1;32m    330\u001b[0m     )\n\u001b[0;32m--> 331\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m/workspace/nflbigdatabowl2023/.venv/lib/python3.8/site-packages/pandas/io/parsers/readers.py:950\u001b[0m, in \u001b[0;36mread_csv\u001b[0;34m(filepath_or_buffer, sep, delimiter, header, names, index_col, usecols, squeeze, prefix, mangle_dupe_cols, dtype, engine, converters, true_values, false_values, skipinitialspace, skiprows, skipfooter, nrows, na_values, keep_default_na, na_filter, verbose, skip_blank_lines, parse_dates, infer_datetime_format, keep_date_col, date_parser, dayfirst, cache_dates, iterator, chunksize, compression, thousands, decimal, lineterminator, quotechar, quoting, doublequote, escapechar, comment, encoding, encoding_errors, dialect, error_bad_lines, warn_bad_lines, on_bad_lines, delim_whitespace, low_memory, memory_map, float_precision, storage_options)\u001b[0m\n\u001b[1;32m    935\u001b[0m kwds_defaults \u001b[38;5;241m=\u001b[39m _refine_defaults_read(\n\u001b[1;32m    936\u001b[0m     dialect,\n\u001b[1;32m    937\u001b[0m     delimiter,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    946\u001b[0m     defaults\u001b[38;5;241m=\u001b[39m{\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mdelimiter\u001b[39m\u001b[38;5;124m\"\u001b[39m: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m,\u001b[39m\u001b[38;5;124m\"\u001b[39m},\n\u001b[1;32m    947\u001b[0m )\n\u001b[1;32m    948\u001b[0m kwds\u001b[38;5;241m.\u001b[39mupdate(kwds_defaults)\n\u001b[0;32m--> 950\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43m_read\u001b[49m\u001b[43m(\u001b[49m\u001b[43mfilepath_or_buffer\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mkwds\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m/workspace/nflbigdatabowl2023/.venv/lib/python3.8/site-packages/pandas/io/parsers/readers.py:605\u001b[0m, in \u001b[0;36m_read\u001b[0;34m(filepath_or_buffer, kwds)\u001b[0m\n\u001b[1;32m    602\u001b[0m _validate_names(kwds\u001b[38;5;241m.\u001b[39mget(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mnames\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;28;01mNone\u001b[39;00m))\n\u001b[1;32m    604\u001b[0m \u001b[38;5;66;03m# Create the parser.\u001b[39;00m\n\u001b[0;32m--> 605\u001b[0m parser \u001b[38;5;241m=\u001b[39m \u001b[43mTextFileReader\u001b[49m\u001b[43m(\u001b[49m\u001b[43mfilepath_or_buffer\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwds\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    607\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m chunksize \u001b[38;5;129;01mor\u001b[39;00m iterator:\n\u001b[1;32m    608\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m parser\n",
+      "File \u001b[0;32m/workspace/nflbigdatabowl2023/.venv/lib/python3.8/site-packages/pandas/io/parsers/readers.py:1442\u001b[0m, in \u001b[0;36mTextFileReader.__init__\u001b[0;34m(self, f, engine, **kwds)\u001b[0m\n\u001b[1;32m   1439\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39moptions[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mhas_index_names\u001b[39m\u001b[38;5;124m\"\u001b[39m] \u001b[38;5;241m=\u001b[39m kwds[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mhas_index_names\u001b[39m\u001b[38;5;124m\"\u001b[39m]\n\u001b[1;32m   1441\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mhandles: IOHandles \u001b[38;5;241m|\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[0;32m-> 1442\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_engine \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_make_engine\u001b[49m\u001b[43m(\u001b[49m\u001b[43mf\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mengine\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m/workspace/nflbigdatabowl2023/.venv/lib/python3.8/site-packages/pandas/io/parsers/readers.py:1735\u001b[0m, in \u001b[0;36mTextFileReader._make_engine\u001b[0;34m(self, f, engine)\u001b[0m\n\u001b[1;32m   1733\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mb\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m mode:\n\u001b[1;32m   1734\u001b[0m         mode \u001b[38;5;241m+\u001b[39m\u001b[38;5;241m=\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mb\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m-> 1735\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mhandles \u001b[38;5;241m=\u001b[39m \u001b[43mget_handle\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m   1736\u001b[0m \u001b[43m    \u001b[49m\u001b[43mf\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1737\u001b[0m \u001b[43m    \u001b[49m\u001b[43mmode\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1738\u001b[0m \u001b[43m    \u001b[49m\u001b[43mencoding\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43moptions\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mencoding\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1739\u001b[0m \u001b[43m    \u001b[49m\u001b[43mcompression\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43moptions\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mcompression\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1740\u001b[0m \u001b[43m    \u001b[49m\u001b[43mmemory_map\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43moptions\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mmemory_map\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mFalse\u001b[39;49;00m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1741\u001b[0m \u001b[43m    \u001b[49m\u001b[43mis_text\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mis_text\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1742\u001b[0m \u001b[43m    \u001b[49m\u001b[43merrors\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43moptions\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mencoding_errors\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mstrict\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1743\u001b[0m \u001b[43m    \u001b[49m\u001b[43mstorage_options\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43moptions\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mstorage_options\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1744\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1745\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mhandles \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[1;32m   1746\u001b[0m f \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mhandles\u001b[38;5;241m.\u001b[39mhandle\n",
+      "File \u001b[0;32m/workspace/nflbigdatabowl2023/.venv/lib/python3.8/site-packages/pandas/io/common.py:856\u001b[0m, in \u001b[0;36mget_handle\u001b[0;34m(path_or_buf, mode, encoding, compression, memory_map, is_text, errors, storage_options)\u001b[0m\n\u001b[1;32m    851\u001b[0m \u001b[38;5;28;01melif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(handle, \u001b[38;5;28mstr\u001b[39m):\n\u001b[1;32m    852\u001b[0m     \u001b[38;5;66;03m# Check whether the filename is to be opened in binary mode.\u001b[39;00m\n\u001b[1;32m    853\u001b[0m     \u001b[38;5;66;03m# Binary mode does not support 'encoding' and 'newline'.\u001b[39;00m\n\u001b[1;32m    854\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m ioargs\u001b[38;5;241m.\u001b[39mencoding \u001b[38;5;129;01mand\u001b[39;00m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mb\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m ioargs\u001b[38;5;241m.\u001b[39mmode:\n\u001b[1;32m    855\u001b[0m         \u001b[38;5;66;03m# Encoding\u001b[39;00m\n\u001b[0;32m--> 856\u001b[0m         handle \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mopen\u001b[39;49m\u001b[43m(\u001b[49m\n\u001b[1;32m    857\u001b[0m \u001b[43m            \u001b[49m\u001b[43mhandle\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    858\u001b[0m \u001b[43m            \u001b[49m\u001b[43mioargs\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmode\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    859\u001b[0m \u001b[43m            \u001b[49m\u001b[43mencoding\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mioargs\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mencoding\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    860\u001b[0m \u001b[43m            \u001b[49m\u001b[43merrors\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43merrors\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    861\u001b[0m \u001b[43m            \u001b[49m\u001b[43mnewline\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[1;32m    862\u001b[0m \u001b[43m        \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    863\u001b[0m     \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m    864\u001b[0m         \u001b[38;5;66;03m# Binary mode\u001b[39;00m\n\u001b[1;32m    865\u001b[0m         handle \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mopen\u001b[39m(handle, ioargs\u001b[38;5;241m.\u001b[39mmode)\n",
+      "\u001b[0;31mFileNotFoundError\u001b[0m: [Errno 2] No such file or directory: '/workspace/nflbigdatabowl2023/data/outputs/pocket_areas.csv'"
+     ]
+    }
+   ],
+   "source": [
+    "df_plays_all = pd.read_csv(f\"{DIR}/data/raw/plays.csv\")\n",
+    "df_tracking_display_all = pd.read_csv(f\"{DIR}/data/outputs/tracking_display.csv\")\n",
+    "df_areas_all = pd.read_csv(f\"{DIR}/data/outputs/pocket_areas.csv\")\n",
+    "df_areas_all[\"pocket\"] = df_areas_all[\"pocket\"].apply(literal_eval)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dfb1b8b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from src.visualization.interactive_play_selector import create_interactive_play_selector\n",
+    "\n",
+    "create_interactive_play_selector(\n",
+    "    df_plays_all,\n",
+    "    df_tracking_display_all,\n",
+    "    df_areas_all,\n",
+    "    continuous_update=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "83ed1073",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/notebooks/vinesh/run_pipeline.ipynb
+++ b/notebooks/vinesh/run_pipeline.ipynb
@@ -41,23 +41,13 @@
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/gitpod/.pyenv/versions/3.8.13/lib/python3.8/contextlib.py:120: SAWarning: Skipped unsupported reflection of expression-based index ix_flow_run__coalesce_start_time_expected_start_time_desc\n",
-      "  next(self.gen)\n",
-      "/home/gitpod/.pyenv/versions/3.8.13/lib/python3.8/contextlib.py:120: SAWarning: Skipped unsupported reflection of expression-based index ix_flow_run__coalesce_start_time_expected_start_time_asc\n",
-      "  next(self.gen)\n"
-     ]
-    },
-    {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:17.803 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | prefect.engine - Created flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> for flow<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\"> 'main-flow'</span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:24.302 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | prefect.engine - Created flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> for flow<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\"> 'main-flow'</span>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:17.803 | \u001b[36mINFO\u001b[0m    | prefect.engine - Created flow run\u001b[35m 'little-seagull'\u001b[0m for flow\u001b[1;35m 'main-flow'\u001b[0m\n"
+       "20:29:24.302 | \u001b[36mINFO\u001b[0m    | prefect.engine - Created flow run\u001b[35m 'dramatic-mustang'\u001b[0m for flow\u001b[1;35m 'main-flow'\u001b[0m\n"
       ]
      },
      "metadata": {},
@@ -66,11 +56,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:17.991 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'read_csv-3609c996-0' for task 'read_csv'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:24.517 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Created task run 'read_csv-3609c996-0' for task 'read_csv'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:17.991 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'read_csv-3609c996-0' for task 'read_csv'\n"
+       "20:29:24.517 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Created task run 'read_csv-3609c996-0' for task 'read_csv'\n"
       ]
      },
      "metadata": {},
@@ -79,11 +69,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:17.995 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'read_csv-3609c996-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:24.519 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Executing 'read_csv-3609c996-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:17.995 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'read_csv-3609c996-0' immediately...\n"
+       "20:29:24.519 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Executing 'read_csv-3609c996-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -92,11 +82,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:18.257 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'read_csv-3609c996-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:24.770 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'read_csv-3609c996-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:18.257 | \u001b[36mINFO\u001b[0m    | Task run 'read_csv-3609c996-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:29:24.770 | \u001b[36mINFO\u001b[0m    | Task run 'read_csv-3609c996-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -105,11 +95,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:18.286 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'read_csv-3609c996-1' for task 'read_csv'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:24.795 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Created task run 'read_csv-3609c996-1' for task 'read_csv'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:18.286 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'read_csv-3609c996-1' for task 'read_csv'\n"
+       "20:29:24.795 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Created task run 'read_csv-3609c996-1' for task 'read_csv'\n"
       ]
      },
      "metadata": {},
@@ -118,11 +108,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:18.289 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'read_csv-3609c996-1' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:24.797 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Executing 'read_csv-3609c996-1' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:18.289 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'read_csv-3609c996-1' immediately...\n"
+       "20:29:24.797 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Executing 'read_csv-3609c996-1' immediately...\n"
       ]
      },
      "metadata": {},
@@ -131,11 +121,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:18.395 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'read_csv-3609c996-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:24.888 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'read_csv-3609c996-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:18.395 | \u001b[36mINFO\u001b[0m    | Task run 'read_csv-3609c996-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:29:24.888 | \u001b[36mINFO\u001b[0m    | Task run 'read_csv-3609c996-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -144,11 +134,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:18.429 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'read_tracking_data-e2eae939-0' for task 'read_tracking_data'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:24.914 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Created task run 'read_tracking_data-e2eae939-0' for task 'read_tracking_data'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:18.429 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'read_tracking_data-e2eae939-0' for task 'read_tracking_data'\n"
+       "20:29:24.914 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Created task run 'read_tracking_data-e2eae939-0' for task 'read_tracking_data'\n"
       ]
      },
      "metadata": {},
@@ -157,11 +147,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:18.432 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'read_tracking_data-e2eae939-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:24.916 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Executing 'read_tracking_data-e2eae939-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:18.432 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'read_tracking_data-e2eae939-0' immediately...\n"
+       "20:29:24.916 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Executing 'read_tracking_data-e2eae939-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -170,11 +160,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:22.129 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'read_tracking_data-e2eae939-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:27.833 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'read_tracking_data-e2eae939-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:22.129 | \u001b[36mINFO\u001b[0m    | Task run 'read_tracking_data-e2eae939-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:29:27.833 | \u001b[36mINFO\u001b[0m    | Task run 'read_tracking_data-e2eae939-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -183,11 +173,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:22.154 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'limit_by_child_keys-4238f776-0' for task 'limit_by_child_keys'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:27.861 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Created task run 'limit_by_child_keys-4238f776-0' for task 'limit_by_child_keys'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:22.154 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'limit_by_child_keys-4238f776-0' for task 'limit_by_child_keys'\n"
+       "20:29:27.861 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Created task run 'limit_by_child_keys-4238f776-0' for task 'limit_by_child_keys'\n"
       ]
      },
      "metadata": {},
@@ -196,11 +186,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:22.156 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'limit_by_child_keys-4238f776-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:27.863 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Executing 'limit_by_child_keys-4238f776-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:22.156 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'limit_by_child_keys-4238f776-0' immediately...\n"
+       "20:29:27.863 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Executing 'limit_by_child_keys-4238f776-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -209,11 +199,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:22.219 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'limit_by_child_keys-4238f776-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:27.932 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'limit_by_child_keys-4238f776-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:22.219 | \u001b[36mINFO\u001b[0m    | Task run 'limit_by_child_keys-4238f776-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:29:27.932 | \u001b[36mINFO\u001b[0m    | Task run 'limit_by_child_keys-4238f776-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -222,11 +212,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:22.247 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'limit_by_child_keys-4238f776-1' for task 'limit_by_child_keys'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:27.960 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Created task run 'limit_by_child_keys-4238f776-1' for task 'limit_by_child_keys'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:22.247 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'limit_by_child_keys-4238f776-1' for task 'limit_by_child_keys'\n"
+       "20:29:27.960 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Created task run 'limit_by_child_keys-4238f776-1' for task 'limit_by_child_keys'\n"
       ]
      },
      "metadata": {},
@@ -235,11 +225,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:22.249 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'limit_by_child_keys-4238f776-1' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:27.962 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Executing 'limit_by_child_keys-4238f776-1' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:22.249 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'limit_by_child_keys-4238f776-1' immediately...\n"
+       "20:29:27.962 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Executing 'limit_by_child_keys-4238f776-1' immediately...\n"
       ]
      },
      "metadata": {},
@@ -248,11 +238,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:22.318 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'limit_by_child_keys-4238f776-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:28.033 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'limit_by_child_keys-4238f776-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:22.318 | \u001b[36mINFO\u001b[0m    | Task run 'limit_by_child_keys-4238f776-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:29:28.033 | \u001b[36mINFO\u001b[0m    | Task run 'limit_by_child_keys-4238f776-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -261,11 +251,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:22.348 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'align_tracking_data-ea7afe30-0' for task 'align_tracking_data'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:28.062 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Created task run 'align_tracking_data-ea7afe30-0' for task 'align_tracking_data'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:22.348 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'align_tracking_data-ea7afe30-0' for task 'align_tracking_data'\n"
+       "20:29:28.062 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Created task run 'align_tracking_data-ea7afe30-0' for task 'align_tracking_data'\n"
       ]
      },
      "metadata": {},
@@ -274,11 +264,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:22.350 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'align_tracking_data-ea7afe30-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:28.064 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Executing 'align_tracking_data-ea7afe30-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:22.350 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'align_tracking_data-ea7afe30-0' immediately...\n"
+       "20:29:28.064 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Executing 'align_tracking_data-ea7afe30-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -287,11 +277,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:22.689 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'align_tracking_data-ea7afe30-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:28.397 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'align_tracking_data-ea7afe30-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:22.689 | \u001b[36mINFO\u001b[0m    | Task run 'align_tracking_data-ea7afe30-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:29:28.397 | \u001b[36mINFO\u001b[0m    | Task run 'align_tracking_data-ea7afe30-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -300,11 +290,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:22.718 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'rotate_tracking_data-13ea6cce-0' for task 'rotate_tracking_data'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:28.425 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Created task run 'rotate_tracking_data-13ea6cce-0' for task 'rotate_tracking_data'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:22.718 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'rotate_tracking_data-13ea6cce-0' for task 'rotate_tracking_data'\n"
+       "20:29:28.425 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Created task run 'rotate_tracking_data-13ea6cce-0' for task 'rotate_tracking_data'\n"
       ]
      },
      "metadata": {},
@@ -313,11 +303,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:22.719 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'rotate_tracking_data-13ea6cce-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:28.427 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Executing 'rotate_tracking_data-13ea6cce-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:22.719 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'rotate_tracking_data-13ea6cce-0' immediately...\n"
+       "20:29:28.427 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Executing 'rotate_tracking_data-13ea6cce-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -326,11 +316,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:22.843 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'rotate_tracking_data-13ea6cce-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:28.541 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'rotate_tracking_data-13ea6cce-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:22.843 | \u001b[36mINFO\u001b[0m    | Task run 'rotate_tracking_data-13ea6cce-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:29:28.541 | \u001b[36mINFO\u001b[0m    | Task run 'rotate_tracking_data-13ea6cce-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -339,11 +329,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:22.878 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'get_passer_out_of_pocket-98072e46-0' for task 'get_passer_out_of_pocket'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:28.582 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Created task run 'get_passer_out_of_pocket-98072e46-0' for task 'get_passer_out_of_pocket'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:22.878 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'get_passer_out_of_pocket-98072e46-0' for task 'get_passer_out_of_pocket'\n"
+       "20:29:28.582 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Created task run 'get_passer_out_of_pocket-98072e46-0' for task 'get_passer_out_of_pocket'\n"
       ]
      },
      "metadata": {},
@@ -352,11 +342,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:22.881 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'get_passer_out_of_pocket-98072e46-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:28.585 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Executing 'get_passer_out_of_pocket-98072e46-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:22.881 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'get_passer_out_of_pocket-98072e46-0' immediately...\n"
+       "20:29:28.585 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Executing 'get_passer_out_of_pocket-98072e46-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -365,11 +355,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:27.741 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'get_passer_out_of_pocket-98072e46-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:30.487 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'get_passer_out_of_pocket-98072e46-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:27.741 | \u001b[36mINFO\u001b[0m    | Task run 'get_passer_out_of_pocket-98072e46-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:29:30.487 | \u001b[36mINFO\u001b[0m    | Task run 'get_passer_out_of_pocket-98072e46-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -378,11 +368,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:27.766 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'clean_event_data-657c8302-0' for task 'clean_event_data'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:30.520 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Created task run 'clean_event_data-657c8302-0' for task 'clean_event_data'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:27.766 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'clean_event_data-657c8302-0' for task 'clean_event_data'\n"
+       "20:29:30.520 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Created task run 'clean_event_data-657c8302-0' for task 'clean_event_data'\n"
       ]
      },
      "metadata": {},
@@ -391,11 +381,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:27.769 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'clean_event_data-657c8302-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:30.523 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Executing 'clean_event_data-657c8302-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:27.769 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'clean_event_data-657c8302-0' immediately...\n"
+       "20:29:30.523 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Executing 'clean_event_data-657c8302-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -404,11 +394,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:29.379 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'clean_event_data-657c8302-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:32.148 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'clean_event_data-657c8302-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:29.379 | \u001b[36mINFO\u001b[0m    | Task run 'clean_event_data-657c8302-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:29:32.148 | \u001b[36mINFO\u001b[0m    | Task run 'clean_event_data-657c8302-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -417,11 +407,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:29.406 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'get_pocket_eligibility-6d653879-0' for task 'get_pocket_eligibility'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:32.175 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Created task run 'get_pocket_eligibility-6d653879-0' for task 'get_pocket_eligibility'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:29.406 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'get_pocket_eligibility-6d653879-0' for task 'get_pocket_eligibility'\n"
+       "20:29:32.175 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Created task run 'get_pocket_eligibility-6d653879-0' for task 'get_pocket_eligibility'\n"
       ]
      },
      "metadata": {},
@@ -430,11 +420,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:29.408 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'get_pocket_eligibility-6d653879-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:32.177 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Executing 'get_pocket_eligibility-6d653879-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:29.408 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'get_pocket_eligibility-6d653879-0' immediately...\n"
+       "20:29:32.177 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Executing 'get_pocket_eligibility-6d653879-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -443,11 +433,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:29.583 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'get_pocket_eligibility-6d653879-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:32.342 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'get_pocket_eligibility-6d653879-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:29.583 | \u001b[36mINFO\u001b[0m    | Task run 'get_pocket_eligibility-6d653879-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:29:32.342 | \u001b[36mINFO\u001b[0m    | Task run 'get_pocket_eligibility-6d653879-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -456,11 +446,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:29.610 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'augment_tracking_events-342a9dc3-0' for task 'augment_tracking_events'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:32.370 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Created task run 'augment_tracking_events-342a9dc3-0' for task 'augment_tracking_events'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:29.610 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'augment_tracking_events-342a9dc3-0' for task 'augment_tracking_events'\n"
+       "20:29:32.370 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Created task run 'augment_tracking_events-342a9dc3-0' for task 'augment_tracking_events'\n"
       ]
      },
      "metadata": {},
@@ -469,11 +459,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:29.612 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'augment_tracking_events-342a9dc3-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:32.372 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Executing 'augment_tracking_events-342a9dc3-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:29.612 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'augment_tracking_events-342a9dc3-0' immediately...\n"
+       "20:29:32.372 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Executing 'augment_tracking_events-342a9dc3-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -482,11 +472,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:30.648 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'augment_tracking_events-342a9dc3-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:33.117 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'augment_tracking_events-342a9dc3-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:30.648 | \u001b[36mINFO\u001b[0m    | Task run 'augment_tracking_events-342a9dc3-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:29:33.117 | \u001b[36mINFO\u001b[0m    | Task run 'augment_tracking_events-342a9dc3-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -495,11 +485,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:30.674 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'transform_to_tracking_display-0c78dc49-0' for task 'transform_to_tracking_display'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:33.143 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Created task run 'transform_to_tracking_display-0c78dc49-0' for task 'transform_to_tracking_display'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:30.674 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'transform_to_tracking_display-0c78dc49-0' for task 'transform_to_tracking_display'\n"
+       "20:29:33.143 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Created task run 'transform_to_tracking_display-0c78dc49-0' for task 'transform_to_tracking_display'\n"
       ]
      },
      "metadata": {},
@@ -508,11 +498,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:30.676 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'transform_to_tracking_display-0c78dc49-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:33.145 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Executing 'transform_to_tracking_display-0c78dc49-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:30.676 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'transform_to_tracking_display-0c78dc49-0' immediately...\n"
+       "20:29:33.145 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Executing 'transform_to_tracking_display-0c78dc49-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -521,11 +511,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:33.740 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'transform_to_tracking_display-0c78dc49-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:36.024 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'transform_to_tracking_display-0c78dc49-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:33.740 | \u001b[36mINFO\u001b[0m    | Task run 'transform_to_tracking_display-0c78dc49-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:29:36.024 | \u001b[36mINFO\u001b[0m    | Task run 'transform_to_tracking_display-0c78dc49-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -534,11 +524,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:33.765 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'transform_to_frames-3446c324-0' for task 'transform_to_frames'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:36.053 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Created task run 'transform_to_frames-3446c324-0' for task 'transform_to_frames'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:33.765 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'transform_to_frames-3446c324-0' for task 'transform_to_frames'\n"
+       "20:29:36.053 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Created task run 'transform_to_frames-3446c324-0' for task 'transform_to_frames'\n"
       ]
      },
      "metadata": {},
@@ -547,11 +537,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:33.766 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'transform_to_frames-3446c324-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:36.055 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Executing 'transform_to_frames-3446c324-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:33.766 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'transform_to_frames-3446c324-0' immediately...\n"
+       "20:29:36.055 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Executing 'transform_to_frames-3446c324-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -560,11 +550,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:40.050 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'transform_to_frames-3446c324-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:42.853 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'transform_to_frames-3446c324-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:40.050 | \u001b[36mINFO\u001b[0m    | Task run 'transform_to_frames-3446c324-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:29:42.853 | \u001b[36mINFO\u001b[0m    | Task run 'transform_to_frames-3446c324-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -573,11 +563,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:40.088 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'transform_to_records_per_frame-823b8998-0' for task 'transform_to_records_per_frame'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:42.885 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Created task run 'transform_to_records_per_frame-823b8998-0' for task 'transform_to_records_per_frame'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:40.088 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'transform_to_records_per_frame-823b8998-0' for task 'transform_to_records_per_frame'\n"
+       "20:29:42.885 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Created task run 'transform_to_records_per_frame-823b8998-0' for task 'transform_to_records_per_frame'\n"
       ]
      },
      "metadata": {},
@@ -586,11 +576,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:40.090 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'transform_to_records_per_frame-823b8998-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:42.888 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Executing 'transform_to_records_per_frame-823b8998-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:40.090 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'transform_to_records_per_frame-823b8998-0' immediately...\n"
+       "20:29:42.888 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Executing 'transform_to_records_per_frame-823b8998-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -599,11 +589,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:45.124 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'transform_to_records_per_frame-823b8998-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:47.901 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'transform_to_records_per_frame-823b8998-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:45.124 | \u001b[36mINFO\u001b[0m    | Task run 'transform_to_records_per_frame-823b8998-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:29:47.901 | \u001b[36mINFO\u001b[0m    | Task run 'transform_to_records_per_frame-823b8998-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -612,11 +602,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:45.191 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'calculate_pocket_area-cc18ef62-4' for task 'calculate_pocket_area'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:47.979 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Created task run 'calculate_pocket_area-cc18ef62-0' for task 'calculate_pocket_area'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:45.191 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-4' for task 'calculate_pocket_area'\n"
+       "20:29:47.979 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-0' for task 'calculate_pocket_area'\n"
       ]
      },
      "metadata": {},
@@ -625,11 +615,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:45.194 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-4' for execution.\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:47.982 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-0' for execution.\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:45.194 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-4' for execution.\n"
+       "20:29:47.982 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-0' for execution.\n"
       ]
      },
      "metadata": {},
@@ -638,11 +628,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:45.218 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'calculate_pocket_area-cc18ef62-3' for task 'calculate_pocket_area'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:48.008 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Created task run 'calculate_pocket_area-cc18ef62-2' for task 'calculate_pocket_area'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:45.218 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-3' for task 'calculate_pocket_area'\n"
+       "20:29:48.008 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-2' for task 'calculate_pocket_area'\n"
       ]
      },
      "metadata": {},
@@ -651,11 +641,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:45.220 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-3' for execution.\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:48.010 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-2' for execution.\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:45.220 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-3' for execution.\n"
+       "20:29:48.010 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-2' for execution.\n"
       ]
      },
      "metadata": {},
@@ -664,11 +654,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:45.252 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'calculate_pocket_area-cc18ef62-2' for task 'calculate_pocket_area'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:48.039 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Created task run 'calculate_pocket_area-cc18ef62-1' for task 'calculate_pocket_area'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:45.252 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-2' for task 'calculate_pocket_area'\n"
+       "20:29:48.039 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-1' for task 'calculate_pocket_area'\n"
       ]
      },
      "metadata": {},
@@ -677,11 +667,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:45.255 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-2' for execution.\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:48.042 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-1' for execution.\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:45.255 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-2' for execution.\n"
+       "20:29:48.042 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-1' for execution.\n"
       ]
      },
      "metadata": {},
@@ -690,11 +680,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:45.316 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'calculate_pocket_area-cc18ef62-1' for task 'calculate_pocket_area'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:48.090 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Created task run 'calculate_pocket_area-cc18ef62-3' for task 'calculate_pocket_area'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:45.316 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-1' for task 'calculate_pocket_area'\n"
+       "20:29:48.090 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-3' for task 'calculate_pocket_area'\n"
       ]
      },
      "metadata": {},
@@ -703,11 +693,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:45.319 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-1' for execution.\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:48.092 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-3' for execution.\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:45.319 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-1' for execution.\n"
+       "20:29:48.092 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-3' for execution.\n"
       ]
      },
      "metadata": {},
@@ -716,11 +706,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:45.410 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'calculate_pocket_area-cc18ef62-0' for task 'calculate_pocket_area'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:49.153 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Created task run 'calculate_pocket_area-cc18ef62-4' for task 'calculate_pocket_area'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:45.410 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-0' for task 'calculate_pocket_area'\n"
+       "20:29:49.153 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Created task run 'calculate_pocket_area-cc18ef62-4' for task 'calculate_pocket_area'\n"
       ]
      },
      "metadata": {},
@@ -729,11 +719,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:45.416 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-0' for execution.\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:49.189 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Submitted task run 'calculate_pocket_area-cc18ef62-4' for execution.\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:45.416 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-0' for execution.\n"
+       "20:29:49.189 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Submitted task run 'calculate_pocket_area-cc18ef62-4' for execution.\n"
       ]
      },
      "metadata": {},
@@ -742,11 +732,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:45.542 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'union_dataframes-8a4e3d8f-0' for task 'union_dataframes'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:50.378 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Created task run 'union_dataframes-8a4e3d8f-0' for task 'union_dataframes'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:45.542 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'union_dataframes-8a4e3d8f-0' for task 'union_dataframes'\n"
+       "20:29:50.378 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Created task run 'union_dataframes-8a4e3d8f-0' for task 'union_dataframes'\n"
       ]
      },
      "metadata": {},
@@ -755,11 +745,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:45.547 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'union_dataframes-8a4e3d8f-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:50.429 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Executing 'union_dataframes-8a4e3d8f-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:45.547 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'union_dataframes-8a4e3d8f-0' immediately...\n"
+       "20:29:50.429 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Executing 'union_dataframes-8a4e3d8f-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -768,11 +758,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:21:54.549 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:29:56.821 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:21:54.549 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:29:56.821 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -781,11 +771,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:28.930 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-3' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:32:31.700 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-3' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:24:28.930 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-3' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:32:31.700 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-3' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -794,11 +784,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:51.105 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-4' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:32:52.621 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-4' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:24:51.105 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-4' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:32:52.621 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-4' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -807,11 +797,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:54.071 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-2' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:32:55.906 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-2' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:24:54.071 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-2' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:32:55.906 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-2' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -820,11 +810,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:54.981 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:32:56.684 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_pocket_area-cc18ef62-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:24:54.981 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:32:56.684 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_pocket_area-cc18ef62-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -833,11 +823,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:55.060 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'union_dataframes-8a4e3d8f-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:32:56.785 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'union_dataframes-8a4e3d8f-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:24:55.060 | \u001b[36mINFO\u001b[0m    | Task run 'union_dataframes-8a4e3d8f-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:32:56.785 | \u001b[36mINFO\u001b[0m    | Task run 'union_dataframes-8a4e3d8f-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -846,11 +836,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:55.088 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'get_frames_for_time_windows-182f3eb1-0' for task 'get_frames_for_time_windows'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:32:56.815 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Created task run 'get_frames_for_time_windows-182f3eb1-0' for task 'get_frames_for_time_windows'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:24:55.088 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'get_frames_for_time_windows-182f3eb1-0' for task 'get_frames_for_time_windows'\n"
+       "20:32:56.815 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Created task run 'get_frames_for_time_windows-182f3eb1-0' for task 'get_frames_for_time_windows'\n"
       ]
      },
      "metadata": {},
@@ -859,11 +849,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:55.090 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'get_frames_for_time_windows-182f3eb1-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:32:56.817 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Executing 'get_frames_for_time_windows-182f3eb1-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:24:55.090 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'get_frames_for_time_windows-182f3eb1-0' immediately...\n"
+       "20:32:56.817 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Executing 'get_frames_for_time_windows-182f3eb1-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -872,11 +862,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:55.487 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'get_frames_for_time_windows-182f3eb1-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:32:57.193 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'get_frames_for_time_windows-182f3eb1-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:24:55.487 | \u001b[36mINFO\u001b[0m    | Task run 'get_frames_for_time_windows-182f3eb1-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:32:57.193 | \u001b[36mINFO\u001b[0m    | Task run 'get_frames_for_time_windows-182f3eb1-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -885,11 +875,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:55.518 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'get_play_pocket_metrics-c9059079-0' for task 'get_play_pocket_metrics'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:32:57.217 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Created task run 'get_play_pocket_metrics-c9059079-0' for task 'get_play_pocket_metrics'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:24:55.518 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'get_play_pocket_metrics-c9059079-0' for task 'get_play_pocket_metrics'\n"
+       "20:32:57.217 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Created task run 'get_play_pocket_metrics-c9059079-0' for task 'get_play_pocket_metrics'\n"
       ]
      },
      "metadata": {},
@@ -898,11 +888,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:55.520 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'get_play_pocket_metrics-c9059079-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:32:57.219 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Executing 'get_play_pocket_metrics-c9059079-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:24:55.520 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'get_play_pocket_metrics-c9059079-0' immediately...\n"
+       "20:32:57.219 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Executing 'get_play_pocket_metrics-c9059079-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -911,11 +901,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:56.086 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'get_play_pocket_metrics-c9059079-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:32:57.842 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'get_play_pocket_metrics-c9059079-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:24:56.086 | \u001b[36mINFO\u001b[0m    | Task run 'get_play_pocket_metrics-c9059079-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:32:57.842 | \u001b[36mINFO\u001b[0m    | Task run 'get_play_pocket_metrics-c9059079-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -924,11 +914,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:56.119 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'calculate_average_pocket_area_loss_per_second-c688e278-0' for task 'calculate_average_pocket_area_loss_per_second'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:32:57.884 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Created task run 'calculate_average_pocket_area_loss_per_second-c688e278-0' for task 'calculate_average_pocket_area_loss_per_second'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:24:56.119 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'calculate_average_pocket_area_loss_per_second-c688e278-0' for task 'calculate_average_pocket_area_loss_per_second'\n"
+       "20:32:57.884 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Created task run 'calculate_average_pocket_area_loss_per_second-c688e278-0' for task 'calculate_average_pocket_area_loss_per_second'\n"
       ]
      },
      "metadata": {},
@@ -937,11 +927,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:56.122 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'calculate_average_pocket_area_loss_per_second-c688e278-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:32:57.887 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Executing 'calculate_average_pocket_area_loss_per_second-c688e278-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:24:56.122 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'calculate_average_pocket_area_loss_per_second-c688e278-0' immediately...\n"
+       "20:32:57.887 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Executing 'calculate_average_pocket_area_loss_per_second-c688e278-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -950,11 +940,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:56.733 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_average_pocket_area_loss_per_second-c688e278-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:32:58.602 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'calculate_average_pocket_area_loss_per_second-c688e278-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:24:56.733 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_average_pocket_area_loss_per_second-c688e278-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:32:58.602 | \u001b[36mINFO\u001b[0m    | Task run 'calculate_average_pocket_area_loss_per_second-c688e278-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -963,11 +953,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:56.762 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'write_csv-386fe2af-0' for task 'write_csv'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:32:58.631 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Created task run 'write_csv-386fe2af-0' for task 'write_csv'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:24:56.762 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'write_csv-386fe2af-0' for task 'write_csv'\n"
+       "20:32:58.631 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Created task run 'write_csv-386fe2af-0' for task 'write_csv'\n"
       ]
      },
      "metadata": {},
@@ -976,11 +966,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:24:56.764 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'write_csv-386fe2af-0' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:32:58.633 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Executing 'write_csv-386fe2af-0' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:24:56.764 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'write_csv-386fe2af-0' immediately...\n"
+       "20:32:58.633 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Executing 'write_csv-386fe2af-0' immediately...\n"
       ]
      },
      "metadata": {},
@@ -989,11 +979,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:25:13.471 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:33:15.292 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-0' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:25:13.471 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:33:15.292 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-0' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -1002,11 +992,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:25:13.509 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'write_csv-386fe2af-1' for task 'write_csv'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:33:15.323 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Created task run 'write_csv-386fe2af-1' for task 'write_csv'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:25:13.509 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'write_csv-386fe2af-1' for task 'write_csv'\n"
+       "20:33:15.323 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Created task run 'write_csv-386fe2af-1' for task 'write_csv'\n"
       ]
      },
      "metadata": {},
@@ -1015,11 +1005,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:25:13.512 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'write_csv-386fe2af-1' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:33:15.326 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Executing 'write_csv-386fe2af-1' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:25:13.512 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'write_csv-386fe2af-1' immediately...\n"
+       "20:33:15.326 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Executing 'write_csv-386fe2af-1' immediately...\n"
       ]
      },
      "metadata": {},
@@ -1028,11 +1018,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:25:13.824 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:33:15.633 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-1' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:25:13.824 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:33:15.633 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-1' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -1041,11 +1031,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:25:13.853 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'write_csv-386fe2af-2' for task 'write_csv'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:33:15.660 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Created task run 'write_csv-386fe2af-2' for task 'write_csv'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:25:13.853 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'write_csv-386fe2af-2' for task 'write_csv'\n"
+       "20:33:15.660 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Created task run 'write_csv-386fe2af-2' for task 'write_csv'\n"
       ]
      },
      "metadata": {},
@@ -1054,11 +1044,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:25:13.856 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'write_csv-386fe2af-2' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:33:15.662 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Executing 'write_csv-386fe2af-2' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:25:13.856 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'write_csv-386fe2af-2' immediately...\n"
+       "20:33:15.662 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Executing 'write_csv-386fe2af-2' immediately...\n"
       ]
      },
      "metadata": {},
@@ -1067,11 +1057,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:25:20.918 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-2' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:33:22.364 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-2' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:25:20.918 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-2' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:33:22.364 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-2' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -1080,11 +1070,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:25:20.949 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Created task run 'write_csv-386fe2af-3' for task 'write_csv'\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:33:22.391 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Created task run 'write_csv-386fe2af-3' for task 'write_csv'\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:25:20.949 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Created task run 'write_csv-386fe2af-3' for task 'write_csv'\n"
+       "20:33:22.391 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Created task run 'write_csv-386fe2af-3' for task 'write_csv'\n"
       ]
      },
      "metadata": {},
@@ -1093,11 +1083,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:25:20.951 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Executing 'write_csv-386fe2af-3' immediately...\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:33:22.393 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Executing 'write_csv-386fe2af-3' immediately...\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:25:20.951 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Executing 'write_csv-386fe2af-3' immediately...\n"
+       "20:33:22.393 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Executing 'write_csv-386fe2af-3' immediately...\n"
       ]
      },
      "metadata": {},
@@ -1106,11 +1096,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:25:21.645 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-3' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:33:23.081 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Task run 'write_csv-386fe2af-3' - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>()\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:25:21.645 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-3' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
+       "20:33:23.081 | \u001b[36mINFO\u001b[0m    | Task run 'write_csv-386fe2af-3' - Finished in state \u001b[32mCompleted\u001b[0m()\n"
       ]
      },
      "metadata": {},
@@ -1119,11 +1109,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:25:21.691 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'little-seagull'</span> - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>('All states completed.')\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">20:33:23.127 | <span style=\"color: #008080; text-decoration-color: #008080\">INFO</span>    | Flow run<span style=\"color: #800080; text-decoration-color: #800080\"> 'dramatic-mustang'</span> - Finished in state <span style=\"color: #008000; text-decoration-color: #008000\">Completed</span>('All states completed.')\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "20:25:21.691 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'little-seagull'\u001b[0m - Finished in state \u001b[32mCompleted\u001b[0m('All states completed.')\n"
+       "20:33:23.127 | \u001b[36mINFO\u001b[0m    | Flow run\u001b[35m 'dramatic-mustang'\u001b[0m - Finished in state \u001b[32mCompleted\u001b[0m('All states completed.')\n"
       ]
      },
      "metadata": {},
@@ -1138,102 +1128,102 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "fe6e342d",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Copy the raw Prefect log from above and paste it into this multi-line variable.\n",
     "raw_log = \"\"\"\n",
-    "20:21:17.803 | INFO    | prefect.engine - Created flow run 'little-seagull' for flow 'main-flow'\n",
-    "20:21:17.991 | INFO    | Flow run 'little-seagull' - Created task run 'read_csv-3609c996-0' for task 'read_csv'\n",
-    "20:21:17.995 | INFO    | Flow run 'little-seagull' - Executing 'read_csv-3609c996-0' immediately...\n",
-    "20:21:18.257 | INFO    | Task run 'read_csv-3609c996-0' - Finished in state Completed()\n",
-    "20:21:18.286 | INFO    | Flow run 'little-seagull' - Created task run 'read_csv-3609c996-1' for task 'read_csv'\n",
-    "20:21:18.289 | INFO    | Flow run 'little-seagull' - Executing 'read_csv-3609c996-1' immediately...\n",
-    "20:21:18.395 | INFO    | Task run 'read_csv-3609c996-1' - Finished in state Completed()\n",
-    "20:21:18.429 | INFO    | Flow run 'little-seagull' - Created task run 'read_tracking_data-e2eae939-0' for task 'read_tracking_data'\n",
-    "20:21:18.432 | INFO    | Flow run 'little-seagull' - Executing 'read_tracking_data-e2eae939-0' immediately...\n",
-    "20:21:22.129 | INFO    | Task run 'read_tracking_data-e2eae939-0' - Finished in state Completed()\n",
-    "20:21:22.154 | INFO    | Flow run 'little-seagull' - Created task run 'limit_by_child_keys-4238f776-0' for task 'limit_by_child_keys'\n",
-    "20:21:22.156 | INFO    | Flow run 'little-seagull' - Executing 'limit_by_child_keys-4238f776-0' immediately...\n",
-    "20:21:22.219 | INFO    | Task run 'limit_by_child_keys-4238f776-0' - Finished in state Completed()\n",
-    "20:21:22.247 | INFO    | Flow run 'little-seagull' - Created task run 'limit_by_child_keys-4238f776-1' for task 'limit_by_child_keys'\n",
-    "20:21:22.249 | INFO    | Flow run 'little-seagull' - Executing 'limit_by_child_keys-4238f776-1' immediately...\n",
-    "20:21:22.318 | INFO    | Task run 'limit_by_child_keys-4238f776-1' - Finished in state Completed()\n",
-    "20:21:22.348 | INFO    | Flow run 'little-seagull' - Created task run 'align_tracking_data-ea7afe30-0' for task 'align_tracking_data'\n",
-    "20:21:22.350 | INFO    | Flow run 'little-seagull' - Executing 'align_tracking_data-ea7afe30-0' immediately...\n",
-    "20:21:22.689 | INFO    | Task run 'align_tracking_data-ea7afe30-0' - Finished in state Completed()\n",
-    "20:21:22.718 | INFO    | Flow run 'little-seagull' - Created task run 'rotate_tracking_data-13ea6cce-0' for task 'rotate_tracking_data'\n",
-    "20:21:22.719 | INFO    | Flow run 'little-seagull' - Executing 'rotate_tracking_data-13ea6cce-0' immediately...\n",
-    "20:21:22.843 | INFO    | Task run 'rotate_tracking_data-13ea6cce-0' - Finished in state Completed()\n",
-    "20:21:22.878 | INFO    | Flow run 'little-seagull' - Created task run 'get_passer_out_of_pocket-98072e46-0' for task 'get_passer_out_of_pocket'\n",
-    "20:21:22.881 | INFO    | Flow run 'little-seagull' - Executing 'get_passer_out_of_pocket-98072e46-0' immediately...\n",
-    "20:21:27.741 | INFO    | Task run 'get_passer_out_of_pocket-98072e46-0' - Finished in state Completed()\n",
-    "20:21:27.766 | INFO    | Flow run 'little-seagull' - Created task run 'clean_event_data-657c8302-0' for task 'clean_event_data'\n",
-    "20:21:27.769 | INFO    | Flow run 'little-seagull' - Executing 'clean_event_data-657c8302-0' immediately...\n",
-    "20:21:29.379 | INFO    | Task run 'clean_event_data-657c8302-0' - Finished in state Completed()\n",
-    "20:21:29.406 | INFO    | Flow run 'little-seagull' - Created task run 'get_pocket_eligibility-6d653879-0' for task 'get_pocket_eligibility'\n",
-    "20:21:29.408 | INFO    | Flow run 'little-seagull' - Executing 'get_pocket_eligibility-6d653879-0' immediately...\n",
-    "20:21:29.583 | INFO    | Task run 'get_pocket_eligibility-6d653879-0' - Finished in state Completed()\n",
-    "20:21:29.610 | INFO    | Flow run 'little-seagull' - Created task run 'augment_tracking_events-342a9dc3-0' for task 'augment_tracking_events'\n",
-    "20:21:29.612 | INFO    | Flow run 'little-seagull' - Executing 'augment_tracking_events-342a9dc3-0' immediately...\n",
-    "20:21:30.648 | INFO    | Task run 'augment_tracking_events-342a9dc3-0' - Finished in state Completed()\n",
-    "20:21:30.674 | INFO    | Flow run 'little-seagull' - Created task run 'transform_to_tracking_display-0c78dc49-0' for task 'transform_to_tracking_display'\n",
-    "20:21:30.676 | INFO    | Flow run 'little-seagull' - Executing 'transform_to_tracking_display-0c78dc49-0' immediately...\n",
-    "20:21:33.740 | INFO    | Task run 'transform_to_tracking_display-0c78dc49-0' - Finished in state Completed()\n",
-    "20:21:33.765 | INFO    | Flow run 'little-seagull' - Created task run 'transform_to_frames-3446c324-0' for task 'transform_to_frames'\n",
-    "20:21:33.766 | INFO    | Flow run 'little-seagull' - Executing 'transform_to_frames-3446c324-0' immediately...\n",
-    "20:21:40.050 | INFO    | Task run 'transform_to_frames-3446c324-0' - Finished in state Completed()\n",
-    "20:21:40.088 | INFO    | Flow run 'little-seagull' - Created task run 'transform_to_records_per_frame-823b8998-0' for task 'transform_to_records_per_frame'\n",
-    "20:21:40.090 | INFO    | Flow run 'little-seagull' - Executing 'transform_to_records_per_frame-823b8998-0' immediately...\n",
-    "20:21:45.124 | INFO    | Task run 'transform_to_records_per_frame-823b8998-0' - Finished in state Completed()\n",
-    "20:21:45.191 | INFO    | Flow run 'little-seagull' - Created task run 'calculate_pocket_area-cc18ef62-4' for task 'calculate_pocket_area'\n",
-    "20:21:45.194 | INFO    | Flow run 'little-seagull' - Submitted task run 'calculate_pocket_area-cc18ef62-4' for execution.\n",
-    "20:21:45.218 | INFO    | Flow run 'little-seagull' - Created task run 'calculate_pocket_area-cc18ef62-3' for task 'calculate_pocket_area'\n",
-    "20:21:45.220 | INFO    | Flow run 'little-seagull' - Submitted task run 'calculate_pocket_area-cc18ef62-3' for execution.\n",
-    "20:21:45.252 | INFO    | Flow run 'little-seagull' - Created task run 'calculate_pocket_area-cc18ef62-2' for task 'calculate_pocket_area'\n",
-    "20:21:45.255 | INFO    | Flow run 'little-seagull' - Submitted task run 'calculate_pocket_area-cc18ef62-2' for execution.\n",
-    "20:21:45.316 | INFO    | Flow run 'little-seagull' - Created task run 'calculate_pocket_area-cc18ef62-1' for task 'calculate_pocket_area'\n",
-    "20:21:45.319 | INFO    | Flow run 'little-seagull' - Submitted task run 'calculate_pocket_area-cc18ef62-1' for execution.\n",
-    "20:21:45.410 | INFO    | Flow run 'little-seagull' - Created task run 'calculate_pocket_area-cc18ef62-0' for task 'calculate_pocket_area'\n",
-    "20:21:45.416 | INFO    | Flow run 'little-seagull' - Submitted task run 'calculate_pocket_area-cc18ef62-0' for execution.\n",
-    "20:21:45.542 | INFO    | Flow run 'little-seagull' - Created task run 'union_dataframes-8a4e3d8f-0' for task 'union_dataframes'\n",
-    "20:21:45.547 | INFO    | Flow run 'little-seagull' - Executing 'union_dataframes-8a4e3d8f-0' immediately...\n",
-    "20:21:54.549 | INFO    | Task run 'calculate_pocket_area-cc18ef62-0' - Finished in state Completed()\n",
-    "20:24:28.930 | INFO    | Task run 'calculate_pocket_area-cc18ef62-3' - Finished in state Completed()\n",
-    "20:24:51.105 | INFO    | Task run 'calculate_pocket_area-cc18ef62-4' - Finished in state Completed()\n",
-    "20:24:54.071 | INFO    | Task run 'calculate_pocket_area-cc18ef62-2' - Finished in state Completed()\n",
-    "20:24:54.981 | INFO    | Task run 'calculate_pocket_area-cc18ef62-1' - Finished in state Completed()\n",
-    "20:24:55.060 | INFO    | Task run 'union_dataframes-8a4e3d8f-0' - Finished in state Completed()\n",
-    "20:24:55.088 | INFO    | Flow run 'little-seagull' - Created task run 'get_frames_for_time_windows-182f3eb1-0' for task 'get_frames_for_time_windows'\n",
-    "20:24:55.090 | INFO    | Flow run 'little-seagull' - Executing 'get_frames_for_time_windows-182f3eb1-0' immediately...\n",
-    "20:24:55.487 | INFO    | Task run 'get_frames_for_time_windows-182f3eb1-0' - Finished in state Completed()\n",
-    "20:24:55.518 | INFO    | Flow run 'little-seagull' - Created task run 'get_play_pocket_metrics-c9059079-0' for task 'get_play_pocket_metrics'\n",
-    "20:24:55.520 | INFO    | Flow run 'little-seagull' - Executing 'get_play_pocket_metrics-c9059079-0' immediately...\n",
-    "20:24:56.086 | INFO    | Task run 'get_play_pocket_metrics-c9059079-0' - Finished in state Completed()\n",
-    "20:24:56.119 | INFO    | Flow run 'little-seagull' - Created task run 'calculate_average_pocket_area_loss_per_second-c688e278-0' for task 'calculate_average_pocket_area_loss_per_second'\n",
-    "20:24:56.122 | INFO    | Flow run 'little-seagull' - Executing 'calculate_average_pocket_area_loss_per_second-c688e278-0' immediately...\n",
-    "20:24:56.733 | INFO    | Task run 'calculate_average_pocket_area_loss_per_second-c688e278-0' - Finished in state Completed()\n",
-    "20:24:56.762 | INFO    | Flow run 'little-seagull' - Created task run 'write_csv-386fe2af-0' for task 'write_csv'\n",
-    "20:24:56.764 | INFO    | Flow run 'little-seagull' - Executing 'write_csv-386fe2af-0' immediately...\n",
-    "20:25:13.471 | INFO    | Task run 'write_csv-386fe2af-0' - Finished in state Completed()\n",
-    "20:25:13.509 | INFO    | Flow run 'little-seagull' - Created task run 'write_csv-386fe2af-1' for task 'write_csv'\n",
-    "20:25:13.512 | INFO    | Flow run 'little-seagull' - Executing 'write_csv-386fe2af-1' immediately...\n",
-    "20:25:13.824 | INFO    | Task run 'write_csv-386fe2af-1' - Finished in state Completed()\n",
-    "20:25:13.853 | INFO    | Flow run 'little-seagull' - Created task run 'write_csv-386fe2af-2' for task 'write_csv'\n",
-    "20:25:13.856 | INFO    | Flow run 'little-seagull' - Executing 'write_csv-386fe2af-2' immediately...\n",
-    "20:25:20.918 | INFO    | Task run 'write_csv-386fe2af-2' - Finished in state Completed()\n",
-    "20:25:20.949 | INFO    | Flow run 'little-seagull' - Created task run 'write_csv-386fe2af-3' for task 'write_csv'\n",
-    "20:25:20.951 | INFO    | Flow run 'little-seagull' - Executing 'write_csv-386fe2af-3' immediately...\n",
-    "20:25:21.645 | INFO    | Task run 'write_csv-386fe2af-3' - Finished in state Completed()\n",
-    "20:25:21.691 | INFO    | Flow run 'little-seagull' - Finished in state Completed('All states completed.')\n",
+    "20:29:24.302 | INFO    | prefect.engine - Created flow run 'dramatic-mustang' for flow 'main-flow'\n",
+    "20:29:24.517 | INFO    | Flow run 'dramatic-mustang' - Created task run 'read_csv-3609c996-0' for task 'read_csv'\n",
+    "20:29:24.519 | INFO    | Flow run 'dramatic-mustang' - Executing 'read_csv-3609c996-0' immediately...\n",
+    "20:29:24.770 | INFO    | Task run 'read_csv-3609c996-0' - Finished in state Completed()\n",
+    "20:29:24.795 | INFO    | Flow run 'dramatic-mustang' - Created task run 'read_csv-3609c996-1' for task 'read_csv'\n",
+    "20:29:24.797 | INFO    | Flow run 'dramatic-mustang' - Executing 'read_csv-3609c996-1' immediately...\n",
+    "20:29:24.888 | INFO    | Task run 'read_csv-3609c996-1' - Finished in state Completed()\n",
+    "20:29:24.914 | INFO    | Flow run 'dramatic-mustang' - Created task run 'read_tracking_data-e2eae939-0' for task 'read_tracking_data'\n",
+    "20:29:24.916 | INFO    | Flow run 'dramatic-mustang' - Executing 'read_tracking_data-e2eae939-0' immediately...\n",
+    "20:29:27.833 | INFO    | Task run 'read_tracking_data-e2eae939-0' - Finished in state Completed()\n",
+    "20:29:27.861 | INFO    | Flow run 'dramatic-mustang' - Created task run 'limit_by_child_keys-4238f776-0' for task 'limit_by_child_keys'\n",
+    "20:29:27.863 | INFO    | Flow run 'dramatic-mustang' - Executing 'limit_by_child_keys-4238f776-0' immediately...\n",
+    "20:29:27.932 | INFO    | Task run 'limit_by_child_keys-4238f776-0' - Finished in state Completed()\n",
+    "20:29:27.960 | INFO    | Flow run 'dramatic-mustang' - Created task run 'limit_by_child_keys-4238f776-1' for task 'limit_by_child_keys'\n",
+    "20:29:27.962 | INFO    | Flow run 'dramatic-mustang' - Executing 'limit_by_child_keys-4238f776-1' immediately...\n",
+    "20:29:28.033 | INFO    | Task run 'limit_by_child_keys-4238f776-1' - Finished in state Completed()\n",
+    "20:29:28.062 | INFO    | Flow run 'dramatic-mustang' - Created task run 'align_tracking_data-ea7afe30-0' for task 'align_tracking_data'\n",
+    "20:29:28.064 | INFO    | Flow run 'dramatic-mustang' - Executing 'align_tracking_data-ea7afe30-0' immediately...\n",
+    "20:29:28.397 | INFO    | Task run 'align_tracking_data-ea7afe30-0' - Finished in state Completed()\n",
+    "20:29:28.425 | INFO    | Flow run 'dramatic-mustang' - Created task run 'rotate_tracking_data-13ea6cce-0' for task 'rotate_tracking_data'\n",
+    "20:29:28.427 | INFO    | Flow run 'dramatic-mustang' - Executing 'rotate_tracking_data-13ea6cce-0' immediately...\n",
+    "20:29:28.541 | INFO    | Task run 'rotate_tracking_data-13ea6cce-0' - Finished in state Completed()\n",
+    "20:29:28.582 | INFO    | Flow run 'dramatic-mustang' - Created task run 'get_passer_out_of_pocket-98072e46-0' for task 'get_passer_out_of_pocket'\n",
+    "20:29:28.585 | INFO    | Flow run 'dramatic-mustang' - Executing 'get_passer_out_of_pocket-98072e46-0' immediately...\n",
+    "20:29:30.487 | INFO    | Task run 'get_passer_out_of_pocket-98072e46-0' - Finished in state Completed()\n",
+    "20:29:30.520 | INFO    | Flow run 'dramatic-mustang' - Created task run 'clean_event_data-657c8302-0' for task 'clean_event_data'\n",
+    "20:29:30.523 | INFO    | Flow run 'dramatic-mustang' - Executing 'clean_event_data-657c8302-0' immediately...\n",
+    "20:29:32.148 | INFO    | Task run 'clean_event_data-657c8302-0' - Finished in state Completed()\n",
+    "20:29:32.175 | INFO    | Flow run 'dramatic-mustang' - Created task run 'get_pocket_eligibility-6d653879-0' for task 'get_pocket_eligibility'\n",
+    "20:29:32.177 | INFO    | Flow run 'dramatic-mustang' - Executing 'get_pocket_eligibility-6d653879-0' immediately...\n",
+    "20:29:32.342 | INFO    | Task run 'get_pocket_eligibility-6d653879-0' - Finished in state Completed()\n",
+    "20:29:32.370 | INFO    | Flow run 'dramatic-mustang' - Created task run 'augment_tracking_events-342a9dc3-0' for task 'augment_tracking_events'\n",
+    "20:29:32.372 | INFO    | Flow run 'dramatic-mustang' - Executing 'augment_tracking_events-342a9dc3-0' immediately...\n",
+    "20:29:33.117 | INFO    | Task run 'augment_tracking_events-342a9dc3-0' - Finished in state Completed()\n",
+    "20:29:33.143 | INFO    | Flow run 'dramatic-mustang' - Created task run 'transform_to_tracking_display-0c78dc49-0' for task 'transform_to_tracking_display'\n",
+    "20:29:33.145 | INFO    | Flow run 'dramatic-mustang' - Executing 'transform_to_tracking_display-0c78dc49-0' immediately...\n",
+    "20:29:36.024 | INFO    | Task run 'transform_to_tracking_display-0c78dc49-0' - Finished in state Completed()\n",
+    "20:29:36.053 | INFO    | Flow run 'dramatic-mustang' - Created task run 'transform_to_frames-3446c324-0' for task 'transform_to_frames'\n",
+    "20:29:36.055 | INFO    | Flow run 'dramatic-mustang' - Executing 'transform_to_frames-3446c324-0' immediately...\n",
+    "20:29:42.853 | INFO    | Task run 'transform_to_frames-3446c324-0' - Finished in state Completed()\n",
+    "20:29:42.885 | INFO    | Flow run 'dramatic-mustang' - Created task run 'transform_to_records_per_frame-823b8998-0' for task 'transform_to_records_per_frame'\n",
+    "20:29:42.888 | INFO    | Flow run 'dramatic-mustang' - Executing 'transform_to_records_per_frame-823b8998-0' immediately...\n",
+    "20:29:47.901 | INFO    | Task run 'transform_to_records_per_frame-823b8998-0' - Finished in state Completed()\n",
+    "20:29:47.979 | INFO    | Flow run 'dramatic-mustang' - Created task run 'calculate_pocket_area-cc18ef62-0' for task 'calculate_pocket_area'\n",
+    "20:29:47.982 | INFO    | Flow run 'dramatic-mustang' - Submitted task run 'calculate_pocket_area-cc18ef62-0' for execution.\n",
+    "20:29:48.008 | INFO    | Flow run 'dramatic-mustang' - Created task run 'calculate_pocket_area-cc18ef62-2' for task 'calculate_pocket_area'\n",
+    "20:29:48.010 | INFO    | Flow run 'dramatic-mustang' - Submitted task run 'calculate_pocket_area-cc18ef62-2' for execution.\n",
+    "20:29:48.039 | INFO    | Flow run 'dramatic-mustang' - Created task run 'calculate_pocket_area-cc18ef62-1' for task 'calculate_pocket_area'\n",
+    "20:29:48.042 | INFO    | Flow run 'dramatic-mustang' - Submitted task run 'calculate_pocket_area-cc18ef62-1' for execution.\n",
+    "20:29:48.090 | INFO    | Flow run 'dramatic-mustang' - Created task run 'calculate_pocket_area-cc18ef62-3' for task 'calculate_pocket_area'\n",
+    "20:29:48.092 | INFO    | Flow run 'dramatic-mustang' - Submitted task run 'calculate_pocket_area-cc18ef62-3' for execution.\n",
+    "20:29:49.153 | INFO    | Flow run 'dramatic-mustang' - Created task run 'calculate_pocket_area-cc18ef62-4' for task 'calculate_pocket_area'\n",
+    "20:29:49.189 | INFO    | Flow run 'dramatic-mustang' - Submitted task run 'calculate_pocket_area-cc18ef62-4' for execution.\n",
+    "20:29:50.378 | INFO    | Flow run 'dramatic-mustang' - Created task run 'union_dataframes-8a4e3d8f-0' for task 'union_dataframes'\n",
+    "20:29:50.429 | INFO    | Flow run 'dramatic-mustang' - Executing 'union_dataframes-8a4e3d8f-0' immediately...\n",
+    "20:29:56.821 | INFO    | Task run 'calculate_pocket_area-cc18ef62-0' - Finished in state Completed()\n",
+    "20:32:31.700 | INFO    | Task run 'calculate_pocket_area-cc18ef62-3' - Finished in state Completed()\n",
+    "20:32:52.621 | INFO    | Task run 'calculate_pocket_area-cc18ef62-4' - Finished in state Completed()\n",
+    "20:32:55.906 | INFO    | Task run 'calculate_pocket_area-cc18ef62-2' - Finished in state Completed()\n",
+    "20:32:56.684 | INFO    | Task run 'calculate_pocket_area-cc18ef62-1' - Finished in state Completed()\n",
+    "20:32:56.785 | INFO    | Task run 'union_dataframes-8a4e3d8f-0' - Finished in state Completed()\n",
+    "20:32:56.815 | INFO    | Flow run 'dramatic-mustang' - Created task run 'get_frames_for_time_windows-182f3eb1-0' for task 'get_frames_for_time_windows'\n",
+    "20:32:56.817 | INFO    | Flow run 'dramatic-mustang' - Executing 'get_frames_for_time_windows-182f3eb1-0' immediately...\n",
+    "20:32:57.193 | INFO    | Task run 'get_frames_for_time_windows-182f3eb1-0' - Finished in state Completed()\n",
+    "20:32:57.217 | INFO    | Flow run 'dramatic-mustang' - Created task run 'get_play_pocket_metrics-c9059079-0' for task 'get_play_pocket_metrics'\n",
+    "20:32:57.219 | INFO    | Flow run 'dramatic-mustang' - Executing 'get_play_pocket_metrics-c9059079-0' immediately...\n",
+    "20:32:57.842 | INFO    | Task run 'get_play_pocket_metrics-c9059079-0' - Finished in state Completed()\n",
+    "20:32:57.884 | INFO    | Flow run 'dramatic-mustang' - Created task run 'calculate_average_pocket_area_loss_per_second-c688e278-0' for task 'calculate_average_pocket_area_loss_per_second'\n",
+    "20:32:57.887 | INFO    | Flow run 'dramatic-mustang' - Executing 'calculate_average_pocket_area_loss_per_second-c688e278-0' immediately...\n",
+    "20:32:58.602 | INFO    | Task run 'calculate_average_pocket_area_loss_per_second-c688e278-0' - Finished in state Completed()\n",
+    "20:32:58.631 | INFO    | Flow run 'dramatic-mustang' - Created task run 'write_csv-386fe2af-0' for task 'write_csv'\n",
+    "20:32:58.633 | INFO    | Flow run 'dramatic-mustang' - Executing 'write_csv-386fe2af-0' immediately...\n",
+    "20:33:15.292 | INFO    | Task run 'write_csv-386fe2af-0' - Finished in state Completed()\n",
+    "20:33:15.323 | INFO    | Flow run 'dramatic-mustang' - Created task run 'write_csv-386fe2af-1' for task 'write_csv'\n",
+    "20:33:15.326 | INFO    | Flow run 'dramatic-mustang' - Executing 'write_csv-386fe2af-1' immediately...\n",
+    "20:33:15.633 | INFO    | Task run 'write_csv-386fe2af-1' - Finished in state Completed()\n",
+    "20:33:15.660 | INFO    | Flow run 'dramatic-mustang' - Created task run 'write_csv-386fe2af-2' for task 'write_csv'\n",
+    "20:33:15.662 | INFO    | Flow run 'dramatic-mustang' - Executing 'write_csv-386fe2af-2' immediately...\n",
+    "20:33:22.364 | INFO    | Task run 'write_csv-386fe2af-2' - Finished in state Completed()\n",
+    "20:33:22.391 | INFO    | Flow run 'dramatic-mustang' - Created task run 'write_csv-386fe2af-3' for task 'write_csv'\n",
+    "20:33:22.393 | INFO    | Flow run 'dramatic-mustang' - Executing 'write_csv-386fe2af-3' immediately...\n",
+    "20:33:23.081 | INFO    | Task run 'write_csv-386fe2af-3' - Finished in state Completed()\n",
+    "20:33:23.127 | INFO    | Flow run 'dramatic-mustang' - Finished in state Completed('All states completed.')\n",
     "\"\"\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "98504fe4",
    "metadata": {},
    "outputs": [
@@ -1266,22 +1256,22 @@
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>calculate_pocket_area-cc18ef62-1</td>\n",
-       "      <td>189.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>22</th>\n",
-       "      <td>union_dataframes-8a4e3d8f-0</td>\n",
-       "      <td>189.0</td>\n",
+       "      <td>188.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
        "      <td>calculate_pocket_area-cc18ef62-2</td>\n",
-       "      <td>188.0</td>\n",
+       "      <td>187.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>22</th>\n",
+       "      <td>union_dataframes-8a4e3d8f-0</td>\n",
+       "      <td>186.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
        "      <td>calculate_pocket_area-cc18ef62-4</td>\n",
-       "      <td>185.0</td>\n",
+       "      <td>183.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
@@ -1296,12 +1286,12 @@
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>calculate_pocket_area-cc18ef62-0</td>\n",
-       "      <td>9.0</td>\n",
+       "      <td>8.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>25</th>\n",
        "      <td>write_csv-386fe2af-2</td>\n",
-       "      <td>7.0</td>\n",
+       "      <td>6.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>19</th>\n",
@@ -1314,19 +1304,14 @@
        "      <td>5.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>10</th>\n",
-       "      <td>get_passer_out_of_pocket-98072e46-0</td>\n",
-       "      <td>4.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
        "      <th>17</th>\n",
        "      <td>read_tracking_data-e2eae939-0</td>\n",
-       "      <td>3.0</td>\n",
+       "      <td>2.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>21</th>\n",
        "      <td>transform_to_tracking_display-0c78dc49-0</td>\n",
-       "      <td>3.0</td>\n",
+       "      <td>2.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>8</th>\n",
@@ -1334,8 +1319,8 @@
        "      <td>1.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>augment_tracking_events-342a9dc3-0</td>\n",
+       "      <th>10</th>\n",
+       "      <td>get_passer_out_of_pocket-98072e46-0</td>\n",
        "      <td>1.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -1344,13 +1329,13 @@
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>18</th>\n",
-       "      <td>rotate_tracking_data-13ea6cce-0</td>\n",
+       "      <th>24</th>\n",
+       "      <td>write_csv-386fe2af-1</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>24</th>\n",
-       "      <td>write_csv-386fe2af-1</td>\n",
+       "      <th>18</th>\n",
+       "      <td>rotate_tracking_data-13ea6cce-0</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -1371,6 +1356,11 @@
        "    <tr>\n",
        "      <th>14</th>\n",
        "      <td>limit_by_child_keys-4238f776-1</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>augment_tracking_events-342a9dc3-0</td>\n",
        "      <td>0.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -1404,28 +1394,28 @@
       ],
       "text/plain": [
        "                                                 task  elapsed_secs\n",
-       "4                    calculate_pocket_area-cc18ef62-1         189.0\n",
-       "22                        union_dataframes-8a4e3d8f-0         189.0\n",
-       "5                    calculate_pocket_area-cc18ef62-2         188.0\n",
-       "7                    calculate_pocket_area-cc18ef62-4         185.0\n",
+       "4                    calculate_pocket_area-cc18ef62-1         188.0\n",
+       "5                    calculate_pocket_area-cc18ef62-2         187.0\n",
+       "22                        union_dataframes-8a4e3d8f-0         186.0\n",
+       "7                    calculate_pocket_area-cc18ef62-4         183.0\n",
        "6                    calculate_pocket_area-cc18ef62-3         163.0\n",
        "23                               write_csv-386fe2af-0          16.0\n",
-       "3                    calculate_pocket_area-cc18ef62-0           9.0\n",
-       "25                               write_csv-386fe2af-2           7.0\n",
+       "3                    calculate_pocket_area-cc18ef62-0           8.0\n",
+       "25                               write_csv-386fe2af-2           6.0\n",
        "19                     transform_to_frames-3446c324-0           6.0\n",
        "20          transform_to_records_per_frame-823b8998-0           5.0\n",
-       "10                get_passer_out_of_pocket-98072e46-0           4.0\n",
-       "17                      read_tracking_data-e2eae939-0           3.0\n",
-       "21           transform_to_tracking_display-0c78dc49-0           3.0\n",
+       "17                      read_tracking_data-e2eae939-0           2.0\n",
+       "21           transform_to_tracking_display-0c78dc49-0           2.0\n",
        "8                         clean_event_data-657c8302-0           1.0\n",
-       "1                  augment_tracking_events-342a9dc3-0           1.0\n",
+       "10                get_passer_out_of_pocket-98072e46-0           1.0\n",
        "0                      align_tracking_data-ea7afe30-0           0.0\n",
-       "18                    rotate_tracking_data-13ea6cce-0           0.0\n",
        "24                               write_csv-386fe2af-1           0.0\n",
+       "18                    rotate_tracking_data-13ea6cce-0           0.0\n",
        "13                     limit_by_child_keys-4238f776-0           0.0\n",
        "16                                read_csv-3609c996-1           0.0\n",
        "15                                read_csv-3609c996-0           0.0\n",
        "14                     limit_by_child_keys-4238f776-1           0.0\n",
+       "1                  augment_tracking_events-342a9dc3-0           0.0\n",
        "12                  get_pocket_eligibility-6d653879-0           0.0\n",
        "11                 get_play_pocket_metrics-c9059079-0           0.0\n",
        "9              get_frames_for_time_windows-182f3eb1-0           0.0\n",
@@ -1433,7 +1423,7 @@
        "26                               write_csv-386fe2af-3           0.0"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1464,57 +1454,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "79fb17b1",
-   "metadata": {},
-   "outputs": [
-    {
-     "ename": "FileNotFoundError",
-     "evalue": "[Errno 2] No such file or directory: '/workspace/nflbigdatabowl2023/data/outputs/pocket_areas.csv'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[11], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m df_plays_all \u001b[38;5;241m=\u001b[39m pd\u001b[38;5;241m.\u001b[39mread_csv(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mDIR\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m/data/raw/plays.csv\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m      2\u001b[0m \u001b[38;5;66;03m# df_tracking_display_all = pd.read_csv(f\"{DIR}/data/outputs/tracking_display.csv\")\u001b[39;00m\n\u001b[0;32m----> 3\u001b[0m df_areas_all \u001b[38;5;241m=\u001b[39m \u001b[43mpd\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mread_csv\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43mf\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;132;43;01m{\u001b[39;49;00m\u001b[43mDIR\u001b[49m\u001b[38;5;132;43;01m}\u001b[39;49;00m\u001b[38;5;124;43m/data/outputs/pocket_areas.csv\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m      4\u001b[0m df_areas_all[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mpocket\u001b[39m\u001b[38;5;124m\"\u001b[39m] \u001b[38;5;241m=\u001b[39m df_areas_all[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mpocket\u001b[39m\u001b[38;5;124m\"\u001b[39m]\u001b[38;5;241m.\u001b[39mapply(literal_eval)\n",
-      "File \u001b[0;32m/workspace/nflbigdatabowl2023/.venv/lib/python3.8/site-packages/pandas/util/_decorators.py:211\u001b[0m, in \u001b[0;36mdeprecate_kwarg.<locals>._deprecate_kwarg.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    209\u001b[0m     \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m    210\u001b[0m         kwargs[new_arg_name] \u001b[38;5;241m=\u001b[39m new_arg_value\n\u001b[0;32m--> 211\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m/workspace/nflbigdatabowl2023/.venv/lib/python3.8/site-packages/pandas/util/_decorators.py:331\u001b[0m, in \u001b[0;36mdeprecate_nonkeyword_arguments.<locals>.decorate.<locals>.wrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    325\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mlen\u001b[39m(args) \u001b[38;5;241m>\u001b[39m num_allow_args:\n\u001b[1;32m    326\u001b[0m     warnings\u001b[38;5;241m.\u001b[39mwarn(\n\u001b[1;32m    327\u001b[0m         msg\u001b[38;5;241m.\u001b[39mformat(arguments\u001b[38;5;241m=\u001b[39m_format_argument_list(allow_args)),\n\u001b[1;32m    328\u001b[0m         \u001b[38;5;167;01mFutureWarning\u001b[39;00m,\n\u001b[1;32m    329\u001b[0m         stacklevel\u001b[38;5;241m=\u001b[39mfind_stack_level(),\n\u001b[1;32m    330\u001b[0m     )\n\u001b[0;32m--> 331\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mfunc\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m/workspace/nflbigdatabowl2023/.venv/lib/python3.8/site-packages/pandas/io/parsers/readers.py:950\u001b[0m, in \u001b[0;36mread_csv\u001b[0;34m(filepath_or_buffer, sep, delimiter, header, names, index_col, usecols, squeeze, prefix, mangle_dupe_cols, dtype, engine, converters, true_values, false_values, skipinitialspace, skiprows, skipfooter, nrows, na_values, keep_default_na, na_filter, verbose, skip_blank_lines, parse_dates, infer_datetime_format, keep_date_col, date_parser, dayfirst, cache_dates, iterator, chunksize, compression, thousands, decimal, lineterminator, quotechar, quoting, doublequote, escapechar, comment, encoding, encoding_errors, dialect, error_bad_lines, warn_bad_lines, on_bad_lines, delim_whitespace, low_memory, memory_map, float_precision, storage_options)\u001b[0m\n\u001b[1;32m    935\u001b[0m kwds_defaults \u001b[38;5;241m=\u001b[39m _refine_defaults_read(\n\u001b[1;32m    936\u001b[0m     dialect,\n\u001b[1;32m    937\u001b[0m     delimiter,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    946\u001b[0m     defaults\u001b[38;5;241m=\u001b[39m{\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mdelimiter\u001b[39m\u001b[38;5;124m\"\u001b[39m: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m,\u001b[39m\u001b[38;5;124m\"\u001b[39m},\n\u001b[1;32m    947\u001b[0m )\n\u001b[1;32m    948\u001b[0m kwds\u001b[38;5;241m.\u001b[39mupdate(kwds_defaults)\n\u001b[0;32m--> 950\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43m_read\u001b[49m\u001b[43m(\u001b[49m\u001b[43mfilepath_or_buffer\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mkwds\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m/workspace/nflbigdatabowl2023/.venv/lib/python3.8/site-packages/pandas/io/parsers/readers.py:605\u001b[0m, in \u001b[0;36m_read\u001b[0;34m(filepath_or_buffer, kwds)\u001b[0m\n\u001b[1;32m    602\u001b[0m _validate_names(kwds\u001b[38;5;241m.\u001b[39mget(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mnames\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;28;01mNone\u001b[39;00m))\n\u001b[1;32m    604\u001b[0m \u001b[38;5;66;03m# Create the parser.\u001b[39;00m\n\u001b[0;32m--> 605\u001b[0m parser \u001b[38;5;241m=\u001b[39m \u001b[43mTextFileReader\u001b[49m\u001b[43m(\u001b[49m\u001b[43mfilepath_or_buffer\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwds\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    607\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m chunksize \u001b[38;5;129;01mor\u001b[39;00m iterator:\n\u001b[1;32m    608\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m parser\n",
-      "File \u001b[0;32m/workspace/nflbigdatabowl2023/.venv/lib/python3.8/site-packages/pandas/io/parsers/readers.py:1442\u001b[0m, in \u001b[0;36mTextFileReader.__init__\u001b[0;34m(self, f, engine, **kwds)\u001b[0m\n\u001b[1;32m   1439\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39moptions[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mhas_index_names\u001b[39m\u001b[38;5;124m\"\u001b[39m] \u001b[38;5;241m=\u001b[39m kwds[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mhas_index_names\u001b[39m\u001b[38;5;124m\"\u001b[39m]\n\u001b[1;32m   1441\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mhandles: IOHandles \u001b[38;5;241m|\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[0;32m-> 1442\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_engine \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_make_engine\u001b[49m\u001b[43m(\u001b[49m\u001b[43mf\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mengine\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m/workspace/nflbigdatabowl2023/.venv/lib/python3.8/site-packages/pandas/io/parsers/readers.py:1735\u001b[0m, in \u001b[0;36mTextFileReader._make_engine\u001b[0;34m(self, f, engine)\u001b[0m\n\u001b[1;32m   1733\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mb\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m mode:\n\u001b[1;32m   1734\u001b[0m         mode \u001b[38;5;241m+\u001b[39m\u001b[38;5;241m=\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mb\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m-> 1735\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mhandles \u001b[38;5;241m=\u001b[39m \u001b[43mget_handle\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m   1736\u001b[0m \u001b[43m    \u001b[49m\u001b[43mf\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1737\u001b[0m \u001b[43m    \u001b[49m\u001b[43mmode\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1738\u001b[0m \u001b[43m    \u001b[49m\u001b[43mencoding\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43moptions\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mencoding\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1739\u001b[0m \u001b[43m    \u001b[49m\u001b[43mcompression\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43moptions\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mcompression\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1740\u001b[0m \u001b[43m    \u001b[49m\u001b[43mmemory_map\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43moptions\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mmemory_map\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mFalse\u001b[39;49;00m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1741\u001b[0m \u001b[43m    \u001b[49m\u001b[43mis_text\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mis_text\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1742\u001b[0m \u001b[43m    \u001b[49m\u001b[43merrors\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43moptions\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mencoding_errors\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mstrict\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1743\u001b[0m \u001b[43m    \u001b[49m\u001b[43mstorage_options\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43moptions\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mstorage_options\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mNone\u001b[39;49;00m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m   1744\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1745\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mhandles \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[1;32m   1746\u001b[0m f \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mhandles\u001b[38;5;241m.\u001b[39mhandle\n",
-      "File \u001b[0;32m/workspace/nflbigdatabowl2023/.venv/lib/python3.8/site-packages/pandas/io/common.py:856\u001b[0m, in \u001b[0;36mget_handle\u001b[0;34m(path_or_buf, mode, encoding, compression, memory_map, is_text, errors, storage_options)\u001b[0m\n\u001b[1;32m    851\u001b[0m \u001b[38;5;28;01melif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(handle, \u001b[38;5;28mstr\u001b[39m):\n\u001b[1;32m    852\u001b[0m     \u001b[38;5;66;03m# Check whether the filename is to be opened in binary mode.\u001b[39;00m\n\u001b[1;32m    853\u001b[0m     \u001b[38;5;66;03m# Binary mode does not support 'encoding' and 'newline'.\u001b[39;00m\n\u001b[1;32m    854\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m ioargs\u001b[38;5;241m.\u001b[39mencoding \u001b[38;5;129;01mand\u001b[39;00m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mb\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m ioargs\u001b[38;5;241m.\u001b[39mmode:\n\u001b[1;32m    855\u001b[0m         \u001b[38;5;66;03m# Encoding\u001b[39;00m\n\u001b[0;32m--> 856\u001b[0m         handle \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mopen\u001b[39;49m\u001b[43m(\u001b[49m\n\u001b[1;32m    857\u001b[0m \u001b[43m            \u001b[49m\u001b[43mhandle\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    858\u001b[0m \u001b[43m            \u001b[49m\u001b[43mioargs\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmode\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    859\u001b[0m \u001b[43m            \u001b[49m\u001b[43mencoding\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mioargs\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mencoding\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    860\u001b[0m \u001b[43m            \u001b[49m\u001b[43merrors\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43merrors\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    861\u001b[0m \u001b[43m            \u001b[49m\u001b[43mnewline\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[1;32m    862\u001b[0m \u001b[43m        \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    863\u001b[0m     \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m    864\u001b[0m         \u001b[38;5;66;03m# Binary mode\u001b[39;00m\n\u001b[1;32m    865\u001b[0m         handle \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mopen\u001b[39m(handle, ioargs\u001b[38;5;241m.\u001b[39mmode)\n",
-      "\u001b[0;31mFileNotFoundError\u001b[0m: [Errno 2] No such file or directory: '/workspace/nflbigdatabowl2023/data/outputs/pocket_areas.csv'"
-     ]
-    }
-   ],
-   "source": [
-    "df_plays_all = pd.read_csv(f\"{DIR}/data/raw/plays.csv\")\n",
-    "df_tracking_display_all = pd.read_csv(f\"{DIR}/data/outputs/tracking_display.csv\")\n",
-    "df_areas_all = pd.read_csv(f\"{DIR}/data/outputs/pocket_areas.csv\")\n",
-    "df_areas_all[\"pocket\"] = df_areas_all[\"pocket\"].apply(literal_eval)"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": null,
-   "id": "dfb1b8b3",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from src.visualization.interactive_play_selector import create_interactive_play_selector\n",
-    "\n",
-    "create_interactive_play_selector(\n",
-    "    df_plays_all,\n",
-    "    df_tracking_display_all,\n",
-    "    df_areas_all,\n",
-    "    continuous_update=True\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "83ed1073",
+   "id": "bcb7b04d",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nflpocketarea2023"
-version = "0.0.3"
+version = "0.0.8"
 authors = [
   { name="Vinesh Kannan", email="v@hawk.iit.edu" },
   { name="Tabor Alemu", email="talemu@hawk.iit.edu" },
@@ -12,7 +12,7 @@ authors = [
 ]
 description = "NFL Big Data Bowl 2023: Analyzing pocket area."
 readme = "README.md"
-requires-python = ">=3.6"
+requires-python = ">=3.7"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-matplotlib==3.6.2
-numpy==1.24.1
-pandas==1.5.2
+matplotlib==3.5.3
+numpy==1.19.1
+pandas==1.3.5
 Pillow==9.4.0
 prefect==2.7.4
 requests==2.28.1
 seaborn==0.12.2
-scipy==1.9.3
+scipy==1.6.3
 shapely==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-dacite==1.7.0
 matplotlib==3.6.2
 numpy==1.24.1
 pandas==1.5.2

--- a/src/metrics/pocket_area/helpers_test.py
+++ b/src/metrics/pocket_area/helpers_test.py
@@ -1,9 +1,16 @@
+import numpy as np
 import pytest
 
-from src.metrics.pocket_area.base import InvalidPocketError
+from src.metrics.pocket_area.base import (
+    InvalidPocketError,
+    PocketArea,
+    PocketAreaMetadata,
+)
 from src.metrics.pocket_area.helpers import (
     convert_pff_role_to_pocket_role,
     get_distance,
+    pocket_from_json,
+    pocket_to_json,
     split_records_by_role,
 )
 
@@ -59,3 +66,67 @@ def test_convert_pff_role_to_pocket_role():
     assert convert_pff_role_to_pocket_role("Pass Block") == "blocker"
     assert convert_pff_role_to_pocket_role("Football") == "unknown"
     assert convert_pff_role_to_pocket_role("Something Else") == "unknown"
+
+
+def test_pocket_from_json():
+    data = {"area": 7.12, "metadata": {"vertices": [(0, 1), (2, 3)]}}
+    actual = pocket_from_json(data)
+    expected = PocketArea(
+        area=7.12, metadata=PocketAreaMetadata(vertices=[(0, 1), (2, 3)])
+    )
+    assert actual == expected
+
+
+def test_pocket_from_json_null_area():
+    data = {
+        "area": None,
+        "metadata": {
+            "radius": 12,
+            "center": (4, 5),
+        },
+    }
+    actual = pocket_from_json(data)
+    expected = PocketArea(
+        area=np.nan, metadata=PocketAreaMetadata(radius=12, center=(4, 5))
+    )
+    assert actual == expected
+
+
+def test_pocket_from_json_no_metadata():
+    data = {"area": 42}
+    actual = pocket_from_json(data)
+    expected = PocketArea(area=42)
+    assert actual == expected
+
+
+def test_pocket_to_json():
+    pocket = PocketArea(
+        area=7.12, metadata=PocketAreaMetadata(vertices=[(0, 1), (2, 3)])
+    )
+    actual = pocket_to_json(pocket)
+    expected = {"area": 7.12, "metadata": {"vertices": [(0, 1), (2, 3)]}}
+    assert actual == expected
+
+
+def test_pocket_to_json_null_area():
+    pocket = PocketArea(
+        area=np.nan, metadata=PocketAreaMetadata(radius=12, center=(4, 5))
+    )
+    actual = pocket_to_json(pocket)
+    expected = {
+        "area": None,
+        "metadata": {
+            "radius": 12,
+            "center": (4, 5),
+        },
+    }
+    assert actual == expected
+
+
+def test_pocket_to_json_no_metadata():
+    pocket = PocketArea(area=42)
+    actual = pocket_to_json(pocket)
+    expected = {
+        "area": 42,
+    }
+    assert actual == expected

--- a/src/metrics/pocket_area/helpers_test.py
+++ b/src/metrics/pocket_area/helpers_test.py
@@ -72,7 +72,8 @@ def test_pocket_from_json():
     data = {"area": 7.12, "metadata": {"vertices": [(0, 1), (2, 3)]}}
     actual = pocket_from_json(data)
     expected = PocketArea(
-        area=7.12, metadata=PocketAreaMetadata(vertices=[(0, 1), (2, 3)])
+        area=7.12,
+        metadata=PocketAreaMetadata(vertices=[(0, 1), (2, 3)]),
     )
     assert actual == expected
 
@@ -80,10 +81,7 @@ def test_pocket_from_json():
 def test_pocket_from_json_null_area():
     data = {
         "area": None,
-        "metadata": {
-            "radius": 12,
-            "center": (4, 5),
-        },
+        "metadata": {"radius": 12, "center": (4, 5)},
     }
     actual = pocket_from_json(data)
     expected = PocketArea(
@@ -101,7 +99,8 @@ def test_pocket_from_json_no_metadata():
 
 def test_pocket_to_json():
     pocket = PocketArea(
-        area=7.12, metadata=PocketAreaMetadata(vertices=[(0, 1), (2, 3)])
+        area=7.12,
+        metadata=PocketAreaMetadata(vertices=[(0, 1), (2, 3)]),
     )
     actual = pocket_to_json(pocket)
     expected = {"area": 7.12, "metadata": {"vertices": [(0, 1), (2, 3)]}}
@@ -110,15 +109,13 @@ def test_pocket_to_json():
 
 def test_pocket_to_json_null_area():
     pocket = PocketArea(
-        area=np.nan, metadata=PocketAreaMetadata(radius=12, center=(4, 5))
+        area=np.nan,
+        metadata=PocketAreaMetadata(radius=12, center=(4, 5)),
     )
     actual = pocket_to_json(pocket)
     expected = {
         "area": None,
-        "metadata": {
-            "radius": 12,
-            "center": (4, 5),
-        },
+        "metadata": {"radius": 12, "center": (4, 5)},
     }
     assert actual == expected
 
@@ -126,7 +123,5 @@ def test_pocket_to_json_null_area():
 def test_pocket_to_json_no_metadata():
     pocket = PocketArea(area=42)
     actual = pocket_to_json(pocket)
-    expected = {
-        "area": 42,
-    }
+    expected = {"area": 42}
     assert actual == expected

--- a/src/pipeline/flows/main.py
+++ b/src/pipeline/flows/main.py
@@ -31,7 +31,7 @@ DEFAULT_OUTPATH = "/workspace/nflbigdatabowl2023/data/outputs"
 def main_flow(**kwargs):
     # Get flow parameters.
     inpath = kwargs.get("inpath", DEFAULT_INPATH)
-    outpath = kwargs.get("outpath", DEFAULT_INPATH)
+    outpath = kwargs.get("outpath", DEFAULT_OUTPATH)
     # Maximum number of weeks to process. If None, process all.
     max_weeks = kwargs.get("max_weeks", 8)
     # Maximum number of games to process. If None, process all.
@@ -109,9 +109,7 @@ def main_flow(**kwargs):
     )
 
     # Write outputs to disk.
-    task(write_csv)(
-        df_tracking_display, f"{outpath}/outputs/tracking_display.csv"
-    )
-    task(write_csv)(df_events, f"{outpath}/outputs/events.csv")
-    task(write_csv)(df_areas, f"{outpath}/outputs/pocket_areas.csv")
-    task(write_csv)(df_play_metrics, f"{outpath}/outputs/play_metrics.csv")
+    task(write_csv)(df_tracking_display, f"{outpath}/tracking_display.csv")
+    task(write_csv)(df_events, f"{outpath}/events.csv")
+    task(write_csv)(df_areas, f"{outpath}/pocket_areas.csv")
+    task(write_csv)(df_play_metrics, f"{outpath}/play_metrics.csv")

--- a/src/pipeline/tasks/eligibility.py
+++ b/src/pipeline/tasks/eligibility.py
@@ -150,7 +150,7 @@ def get_pocket_eligibility(
     )
 
     # Fill plays with null start and end frames with None.
-    df["frame_start"] = df["frame_start"].fillna(np.nan).replace([np.nan], None)
-    df["frame_end"] = df["frame_end"].fillna(np.nan).replace([np.nan], None)
+    df["frame_start"] = df["frame_start"].fillna(np.nan).replace(np.nan, None)
+    df["frame_end"] = df["frame_end"].fillna(np.nan).replace(np.nan, None)
 
     return df

--- a/src/pipeline/tasks/eligibility.py
+++ b/src/pipeline/tasks/eligibility.py
@@ -150,7 +150,7 @@ def get_pocket_eligibility(
     )
 
     # Fill plays with null start and end frames with None.
-    df["frame_start"] = df["frame_start"].fillna(np.nan).replace(np.nan, None)
-    df["frame_end"] = df["frame_end"].fillna(np.nan).replace(np.nan, None)
+    df["frame_start"] = df["frame_start"].fillna(-1).replace(-1, None)
+    df["frame_end"] = df["frame_end"].fillna(-1).replace(-1, None)
 
     return df

--- a/src/pipeline/tasks/eligibility.py
+++ b/src/pipeline/tasks/eligibility.py
@@ -150,7 +150,6 @@ def get_pocket_eligibility(
     )
 
     # Fill plays with null start and end frames with None.
-
     df["frame_start"] = df["frame_start"].replace({np.nan: None})
     df["frame_end"] = df["frame_end"].replace({np.nan: None})
 

--- a/src/pipeline/tasks/eligibility.py
+++ b/src/pipeline/tasks/eligibility.py
@@ -150,7 +150,8 @@ def get_pocket_eligibility(
     )
 
     # Fill plays with null start and end frames with None.
-    df["frame_start"] = df["frame_start"].fillna(-1).replace(-1, None)
-    df["frame_end"] = df["frame_end"].fillna(-1).replace(-1, None)
+
+    df["frame_start"] = df["frame_start"].replace({np.nan: None})
+    df["frame_end"] = df["frame_end"].replace({np.nan: None})
 
     return df

--- a/src/pipeline/tasks/pocket_area.py
+++ b/src/pipeline/tasks/pocket_area.py
@@ -1,10 +1,10 @@
-import dataclasses
 from typing import Callable, Dict, List, Tuple
 
 import numpy as np
 import pandas as pd
 
 from src.metrics.pocket_area.base import PocketArea, PocketAreaFunction
+from src.metrics.pocket_area.helpers import pocket_to_json
 from src.pipeline.tasks.frames import FRAME_PRIMARY_KEY
 
 
@@ -32,11 +32,7 @@ def calculate_pocket_safely(
             raise TypeError(message)
 
         # Convert the pocket area dataclass to a dictionary.
-        # The dataclass does not allow a None for area, but we cannot parse a
-        # np.nan from a string, so if the area is np.nan, set it to None.
-        pocket_dict = dataclasses.asdict(pocket_area)
-        if np.isnan(pocket_dict["area"]):
-            pocket_dict["area"] = None
+        pocket_dict = pocket_to_json(pocket_area)
         return pocket_dict
 
     return calculate

--- a/src/pipeline/tasks/pocket_area_test.py
+++ b/src/pipeline/tasks/pocket_area_test.py
@@ -39,9 +39,7 @@ def test_calculate_pocket_area():
             "playId": 1,
             "frameId": 1,
             "method": "always_seven",
-            "pocket": {
-                "area": 7,
-            },
+            "pocket": {"area": 7},
             "area": 7,
         },
     ]
@@ -56,9 +54,7 @@ def test_calculate_pocket_safely():
 
     df = pd.DataFrame()
     actual = actual_fn(df)
-    expected = {
-        "area": 7,
-    }
+    expected = {"area": 7}
     assert actual == expected
 
 
@@ -70,9 +66,7 @@ def test_calculate_pocket_safely_with_exception():
 
     df = pd.DataFrame()
     actual = actual_fn(df)
-    expected = {
-        "area": None,
-    }
+    expected = {"area": None}
     assert actual == expected
 
 

--- a/src/pipeline/tasks/pocket_area_test.py
+++ b/src/pipeline/tasks/pocket_area_test.py
@@ -41,11 +41,6 @@ def test_calculate_pocket_area():
             "method": "always_seven",
             "pocket": {
                 "area": 7,
-                "metadata": {
-                    "vertices": None,
-                    "radius": None,
-                    "center": None,
-                },
             },
             "area": 7,
         },
@@ -63,7 +58,6 @@ def test_calculate_pocket_safely():
     actual = actual_fn(df)
     expected = {
         "area": 7,
-        "metadata": {"vertices": None, "radius": None, "center": None},
     }
     assert actual == expected
 
@@ -78,7 +72,6 @@ def test_calculate_pocket_safely_with_exception():
     actual = actual_fn(df)
     expected = {
         "area": None,
-        "metadata": {"vertices": None, "radius": None, "center": None},
     }
     assert actual == expected
 

--- a/src/visualization/interactive_pocket_area.py
+++ b/src/visualization/interactive_pocket_area.py
@@ -1,7 +1,6 @@
 import math
 from typing import Dict, List
 
-import dacite
 import ipywidgets as widgets
 import matplotlib.pyplot as plt
 import pandas as pd

--- a/src/visualization/pocket_area.py
+++ b/src/visualization/pocket_area.py
@@ -1,6 +1,5 @@
 from typing import Dict, Optional
 
-import dacite
 import ipywidgets as widgets
 import matplotlib.pyplot as plt
 import numpy as np
@@ -9,6 +8,7 @@ from matplotlib.patches import Circle, Patch, Polygon
 from matplotlib.ticker import MultipleLocator
 
 from src.metrics.pocket_area.base import InvalidPocketError, PocketArea
+from src.metrics.pocket_area.helpers import pocket_from_json
 
 POCKET_KWARGS = dict(
     color="#b0e3ff",
@@ -27,11 +27,7 @@ def get_pocket_area_nested_map(df_areas: pd.DataFrame) -> PocketAreaNestedMap:
         pocket_dict = row["pocket"]
 
         # Parse pocket area dataclass.
-        # The dataclass does not allow a None for area, but we cannot parse a
-        # np.nan from a string, so if the area is None, set it to np.nan.
-        if pocket_dict["area"] is None:
-            pocket_dict["area"] = np.nan
-        pocket = dacite.from_dict(PocketArea, pocket_dict)
+        pocket = pocket_from_json(pocket_dict)
 
         # Update nested map.
         if frame_id not in output:


### PR DESCRIPTION
- [x] Remove dependency on `dacite` to reduce time spent installing new packages in Kaggle.
- [x] Downgrade dependencies to versions that were found to be compatible with Python 3.7.12.
- [x] Rerun pipeline to verify that changes are successful.
- [x] Fix backwards compatibility issue with Pandas `replace()` to use `None` for missing frame ranges instead of `np.nan`.